### PR TITLE
gluster: fix tcmu_get_attribute error check

### DIFF
--- a/glfs.c
+++ b/glfs.c
@@ -125,7 +125,7 @@ static int tcmu_glfs_open(struct tcmu_device *dev)
 	}
 
 	gfsp->wce = tcmu_get_attribute(dev, "emulate_write_cache");
-	if (gfsp->block_size == -1) {
+	if (gfsp->wce == -1) {
 		printf("Could not get write cache emulation setting\n");
 		goto fail;
 	}


### PR DESCRIPTION
This fixes the wce tcmu_get_attribute() error check, which currently has
a cut-n-paste bug.

Signed-off-by: David Disseldorp <ddiss@suse.de>