### PR TITLE
Factored out SCSI request processing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 tcmu-runner
+consumer
 *.o
 *.a
 *.so

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 tcmu-runner
 *.o
+*.a
 *.so
 *generated.[ch]
 Makefile

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,12 @@ set_target_properties(handler_file
   PREFIX ""
   )
 
+# The minimal library consumer
+add_executable(consumer
+  consumer.c
+  )
+target_link_libraries(consumer tcmu)
+
 # Stuff for building the glfs handler
 add_library(handler_glfs
   SHARED

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,11 +31,15 @@ find_library(KMOD kmod)
 find_library(GFAPI gfapi)
 
 # Stuff for building the main binary
+add_library(tcmu
+  api.c
+  libtcmu.c
+  )
 add_executable(tcmu-runner
   main.c
-  api.c
   tcmuhandler-generated.c
   )
+target_link_libraries(tcmu-runner tcmu)
 target_compile_options(tcmu-runner
   PUBLIC -fPIC -Wl,-E
   )

--- a/api.c
+++ b/api.c
@@ -37,27 +37,6 @@
 
 #define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))
 
-extern bool debug;
-
-void dbgp(const char *fmt, ...)
-{
-	if (debug) {
-		va_list va;
-		va_start(va, fmt);
-		vprintf(fmt, va);
-		va_end(va);
-	}
-}
-
-void errp(const char *fmt, ...)
-{
-	va_list va;
-
-	va_start(va, fmt);
-	vfprintf(stderr, fmt, va);
-	va_end(va);
-}
-
 int tcmu_get_attribute(struct tcmu_device *dev, const char *name)
 {
 	int fd;

--- a/consumer.c
+++ b/consumer.c
@@ -1,0 +1,311 @@
+/*
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+*/
+#define _BSD_SOURCE
+#include <stdlib.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <string.h>
+#include <limits.h>
+#include <endian.h>
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/mman.h>
+
+#include <stdint.h>
+#include <scsi/scsi.h>
+#define _BITS_UIO_H
+#include <linux/target_core_user.h>
+#include "tcmu-runner.h"
+
+/*
+ * Debug API implementation
+ */
+void dbgp(const char *fmt, ...)
+{
+	va_list va;
+	va_start(va, fmt);
+	vprintf(fmt, va);
+	va_end(va);
+}
+
+void errp(const char *fmt, ...)
+{
+	va_list va;
+
+	va_start(va, fmt);
+	vfprintf(stderr, fmt, va);
+	va_end(va);
+}
+
+struct file_state {
+	int fd;
+	uint64_t num_lbas;
+	uint32_t block_size;
+};
+
+static int set_medium_error(uint8_t *sense)
+{
+	return tcmu_set_sense_data(sense, MEDIUM_ERROR, ASC_READ_ERROR, NULL);
+}
+
+static bool file_check_config(const char *cfgstring, char **reason)
+{
+	 return true;
+}
+
+static int file_open(struct tcmu_device *dev)
+{
+	return 0;
+}
+
+static void file_close(struct tcmu_device *dev)
+{
+}
+
+static int file_handle_cmd(
+	struct tcmu_device *dev,
+	uint8_t *cdb,
+	struct iovec *iovec,
+	size_t iov_cnt,
+	uint8_t *sense)
+{
+	struct file_state *state = dev->hm_private;
+	uint8_t cmd;
+
+	cmd = cdb[0];
+
+	switch (cmd) {
+	case INQUIRY:
+		return tcmu_emulate_inquiry(dev, cdb, iovec, iov_cnt, sense);
+		break;
+	case TEST_UNIT_READY:
+		return tcmu_emulate_test_unit_ready(cdb, iovec, iov_cnt, sense);
+		break;
+	case SERVICE_ACTION_IN_16:
+		if (cdb[1] == READ_CAPACITY_16)
+			return tcmu_emulate_read_capacity_16(state->num_lbas,
+							     state->block_size,
+							     cdb, iovec, iov_cnt, sense);
+		else
+			return TCMU_NOT_HANDLED;
+		break;
+	case MODE_SENSE:
+	case MODE_SENSE_10:
+		return tcmu_emulate_mode_sense(cdb, iovec, iov_cnt, sense);
+		break;
+	case MODE_SELECT:
+	case MODE_SELECT_10:
+		return tcmu_emulate_mode_select(cdb, iovec, iov_cnt, sense);
+		break;
+	case READ_6:
+	case READ_10:
+	case READ_12:
+	case READ_16:
+		// A real "read" implementation goes here! 
+		return set_medium_error(sense);
+		
+	case WRITE_6:
+	case WRITE_10:
+	case WRITE_12:
+	case WRITE_16:
+		// A real "write" implemention goes here!
+		return SAM_STAT_GOOD;
+	
+	default:
+		errp("unknown command %x\n", cdb[0]);
+		return TCMU_NOT_HANDLED;
+	}
+}
+
+static struct tcmu_handler file_handler = {
+	.name = "File-backed Handler (example code)",
+	.subtype = "file",
+	.cfg_desc = "a description goes here",
+
+	.check_config = file_check_config,
+
+	.open = file_open,
+	.close = file_close,
+	.handle_cmd = file_handle_cmd,
+};
+
+static struct tcmu_device *add_device(const char *dev_name, const char *cfgstring)
+{
+	struct tcmu_device *dev;
+	struct tcmu_mailbox *mb;
+	char str_buf[256];
+	int fd;
+	int ret;
+	const char *ptr, *oldptr;
+	int len;
+
+	dev = calloc(1, sizeof(*dev));
+	if (!dev) {
+		errp("calloc failed in add_device\n");
+		return NULL;
+	}
+
+	snprintf(dev->dev_name, sizeof(dev->dev_name), "%s", dev_name);
+
+	oldptr = cfgstring;
+	ptr = strchr(oldptr, '/');
+	if (!ptr) {
+		errp("invalid cfgstring\n");
+		goto err_free;
+	}
+
+	if (strncmp(cfgstring, "tcm-user", ptr-oldptr)) {
+		errp("invalid cfgstring\n");
+		goto err_free;
+	}
+
+	/* Get HBA name */
+	oldptr = ptr+1;
+	ptr = strchr(oldptr, '/');
+	if (!ptr) {
+		errp("invalid cfgstring\n");
+		goto err_free;
+	}
+	len = ptr-oldptr;
+	snprintf(dev->tcm_hba_name, sizeof(dev->tcm_hba_name), "user_%.*s", len, oldptr);
+
+	/* Get device name */
+	oldptr = ptr+1;
+	ptr = strchr(oldptr, '/');
+	if (!ptr) {
+		errp("invalid cfgstring\n");
+		goto err_free;
+	}
+	len = ptr-oldptr;
+	snprintf(dev->tcm_dev_name, sizeof(dev->tcm_dev_name), "%.*s", len, oldptr);
+
+	/* The rest is the handler-specific cfgstring */
+	oldptr = ptr+1;
+	ptr = strchr(oldptr, '/');
+	snprintf(dev->cfgstring, sizeof(dev->cfgstring), "%s", oldptr);
+
+	snprintf(str_buf, sizeof(str_buf), "/dev/%s", dev_name);
+
+	dev->fd = open(str_buf, O_RDWR);
+	if (dev->fd == -1) {
+		errp("could not open %s\n", str_buf);
+		goto err_free;
+	}
+
+	snprintf(str_buf, sizeof(str_buf), "/sys/class/uio/%s/maps/map0/size", dev->dev_name);
+	fd = open(str_buf, O_RDONLY);
+	if (fd == -1) {
+		errp("could not open %s\n", str_buf);
+		goto err_fd_close;
+	}
+
+	ret = read(fd, str_buf, sizeof(str_buf));
+	close(fd);
+	if (ret <= 0) {
+		errp("could not read size of map0\n");
+		goto err_fd_close;
+	}
+	str_buf[ret-1] = '\0'; /* null-terminate and chop off the \n */
+
+	dev->map_len = strtoull(str_buf, NULL, 0);
+	if (dev->map_len == ULLONG_MAX) {
+		errp("could not get map length\n");
+		goto err_fd_close;
+	}
+
+	dev->map = mmap(NULL, dev->map_len, PROT_READ|PROT_WRITE, MAP_SHARED, dev->fd, 0);
+	if (dev->map == MAP_FAILED) {
+		errp("could not mmap: %m\n");
+		goto err_fd_close;
+	}
+
+	mb = dev->map;
+	if (mb->version != KERN_IFACE_VER) {
+		errp("Kernel interface version mismatch: wanted %d got %d\n",
+		    KERN_IFACE_VER, mb->version);
+		goto err_munmap;
+	}
+
+	dev->handler = &file_handler;
+
+	ret = dev->handler->open(dev);
+	if (ret < 0) {
+		errp("handler open failed for %s\n", dev->dev_name);
+		goto err_munmap;
+	}
+
+	return dev;
+
+err_munmap:
+	munmap(dev->map, dev->map_len);
+err_fd_close:
+	close(dev->fd);
+err_free:
+	free(dev);
+
+	return NULL;
+}
+
+int main(int argc, char **argv)
+{
+	struct tcmu_device *dev;
+
+	/* 
+	 * configure a  device
+ 	 */
+	{
+		char buf[256];
+		int fd;
+		int ret;
+		const char *path = "/sys/class/uio/uio0/name";
+		
+		fd = open(path, O_RDONLY);
+		if (fd == -1) {
+			errp("main: failed to open %s\n", path);
+			return -1;
+		}
+
+		ret = read(fd, buf, sizeof(buf));
+		close(fd);
+		if (ret <= 0 || ret >= sizeof(buf)) {
+			errp("main: failed to read %s\n", path);
+			return -1;
+		}
+		buf[ret-1] = '\0'; /* null-terminate and chop off the \n */
+
+		dev = add_device("uio0", buf);
+	}
+
+	if (dev == NULL)
+		return -1;
+
+	/* 
+	 * Imagine that we have have just been notified that dev->fd is 
+	 * readable via epoll()
+ 	 */
+	{
+		char buf[4];
+		int ret = read(dev->fd, buf, 4);
+		if (ret != 4) {
+			errp("Nothing to do. Terminating...\n");
+			return -1;
+		}
+	}
+
+	return tcmu_handle_device_events(dev);
+}

--- a/libtcmu.c
+++ b/libtcmu.c
@@ -1,0 +1,111 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+#include <memory.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <stdint.h>
+#include <errno.h>
+#include <scsi/scsi.h>
+#define _BITS_UIO_H
+#include <linux/target_core_user.h>
+
+#include "tcmu-runner.h"
+
+static void handle_one_command(struct tcmu_device *dev,
+		       	       struct tcmu_mailbox *mb,
+		       	       struct tcmu_cmd_entry *ent)
+{
+	uint8_t *cdb = (void *)mb + ent->req.cdb_off;
+	int i;
+	bool short_cdb = cdb[0] <= 0x1f;
+	int result;
+	uint8_t tmp_sense_buf[TCMU_SENSE_BUFFERSIZE];
+
+	/* Convert iovec addrs in-place to not be offsets */
+	for (i = 0; i < ent->req.iov_cnt; i++)
+		ent->req.iov[i].iov_base = (void *) mb +
+			(size_t)ent->req.iov[i].iov_base;
+
+	for (i = 0; i < (short_cdb ? 6 : 10); i++) {
+		dbgp("%x ", cdb[i]);
+	}
+	dbgp("\n");
+
+	result = dev->handler->handle_cmd(dev, cdb, ent->req.iov,
+					  ent->req.iov_cnt, tmp_sense_buf);
+
+	if (result == TCMU_NOT_HANDLED) {
+		/* Tell the kernel we didn't handle it */
+		char *buf = ent->rsp.sense_buffer;
+
+		ent->rsp.scsi_status = SAM_STAT_CHECK_CONDITION;
+
+		buf[0] = 0x70;  /* fixed, current */
+		buf[2] = 0x5;   /* illegal request */
+		buf[7] = 0xa;
+		buf[12] = 0x20; /* ASC: invalid command operation code */
+		buf[13] = 0x0;  /* ASCQ: (none) */
+	} else {
+		if (result != SAM_STAT_GOOD) {
+			memcpy(ent->rsp.sense_buffer, tmp_sense_buf,
+			       TCMU_SENSE_BUFFERSIZE);
+		}
+		ent->rsp.scsi_status = result;
+	}
+}
+
+static int poke_kernel(struct tcmu_device *dev)
+{
+	const uint32_t buf = 0xabcdef12;
+
+	if (write(dev->fd, &buf, 4) != 4) {
+		errp("poke_kernel write error\n");
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+int tcmu_handle_device_events(struct tcmu_device *dev)
+{
+	struct tcmu_mailbox *mb = dev->map;
+	struct tcmu_cmd_entry *ent = (void *) mb + mb->cmdr_off + mb->cmd_tail;
+	int did_some_work = 0;
+
+	while (ent != (void *)mb + mb->cmdr_off + mb->cmd_head) {
+
+		switch (tcmu_hdr_get_op(ent->hdr.len_op)) {
+		case TCMU_OP_PAD:
+			/* do nothing */
+			break;
+		case TCMU_OP_CMD:
+			handle_one_command(dev, mb, ent);
+			break;
+		default:
+			/* We don't even know how to handle this TCMU opcode. */
+			ent->hdr.uflags |= TCMU_UFLAG_UNKNOWN_OP;
+		}
+
+		mb->cmd_tail = (mb->cmd_tail + tcmu_hdr_get_len(ent->hdr.len_op)) % mb->cmdr_size;
+		ent = (void *) mb + mb->cmdr_off + mb->cmd_tail;
+		did_some_work = 1;
+	}
+
+	if (did_some_work)
+		return poke_kernel(dev);
+
+	return 0;
+}

--- a/main.c
+++ b/main.c
@@ -54,8 +54,8 @@
 
 #define KERN_IFACE_VER 2
 
-char *handler_path = DEFAULT_HANDLER_PATH;
-bool debug = false;
+static char *handler_path = DEFAULT_HANDLER_PATH;
+static bool debug = false;
 
 darray(struct tcmu_handler) handlers = darray_new();
 
@@ -73,6 +73,28 @@ static struct nla_policy tcmu_attr_policy[TCMU_ATTR_MAX+1] = {
 
 static int add_device(char *dev_name, char *cfgstring);
 static void remove_device(char *dev_name, char *cfgstring);
+
+/*
+ * Debug API implementation
+ */
+void dbgp(const char *fmt, ...)
+{
+	if (debug) {
+		va_list va;
+		va_start(va, fmt);
+		vprintf(fmt, va);
+		va_end(va);
+	}
+}
+
+void errp(const char *fmt, ...)
+{
+	va_list va;
+
+	va_start(va, fmt);
+	vfprintf(stderr, fmt, va);
+	va_end(va);
+}
 
 static int handle_netlink(struct nl_cache_ops *unused, struct genl_cmd *cmd,
 			  struct genl_info *info, void *arg)
@@ -250,88 +272,6 @@ static struct tcmu_handler *find_handler(char *cfgstring)
 	return NULL;
 }
 
-static void handle_one_command(struct tcmu_device *dev,
-		       struct tcmu_mailbox *mb,
-		       struct tcmu_cmd_entry *ent)
-{
-	uint8_t *cdb = (void *)mb + ent->req.cdb_off;
-	int i;
-	bool short_cdb = cdb[0] <= 0x1f;
-	int result;
-	uint8_t tmp_sense_buf[TCMU_SENSE_BUFFERSIZE];
-
-	/* Convert iovec addrs in-place to not be offsets */
-	for (i = 0; i < ent->req.iov_cnt; i++)
-		ent->req.iov[i].iov_base = (void *) mb +
-			(size_t)ent->req.iov[i].iov_base;
-
-	for (i = 0; i < (short_cdb ? 6 : 10); i++) {
-		dbgp("%x ", cdb[i]);
-	}
-	dbgp("\n");
-
-	result = dev->handler->handle_cmd(dev, cdb, ent->req.iov,
-					  ent->req.iov_cnt, tmp_sense_buf);
-
-	if (result == TCMU_NOT_HANDLED) {
-		/* Tell the kernel we didn't handle it */
-		char *buf = ent->rsp.sense_buffer;
-
-		ent->rsp.scsi_status = SAM_STAT_CHECK_CONDITION;
-
-		buf[0] = 0x70;  /* fixed, current */
-		buf[2] = 0x5;   /* illegal request */
-		buf[7] = 0xa;
-		buf[12] = 0x20; /* ASC: invalid command operation code */
-		buf[13] = 0x0;  /* ASCQ: (none) */
-	} else {
-		if (result != SAM_STAT_GOOD) {
-			memcpy(ent->rsp.sense_buffer, tmp_sense_buf,
-			       TCMU_SENSE_BUFFERSIZE);
-		}
-		ent->rsp.scsi_status = result;
-	}
-}
-
-static void poke_kernel(int fd)
-{
-	uint32_t buf = 0xabcdef12;
-
-	if (write(fd, &buf, 4) != 4)
-		errp("poke_kernel write error\n");
-}
-
-static int handle_device_events(struct tcmu_device *dev)
-{
-	struct tcmu_mailbox *mb = dev->map;
-	struct tcmu_cmd_entry *ent = (void *) mb + mb->cmdr_off + mb->cmd_tail;
-	int did_some_work = 0;
-
-	while (ent != (void *)mb + mb->cmdr_off + mb->cmd_head) {
-
-		switch (tcmu_hdr_get_op(ent->hdr.len_op)) {
-		case TCMU_OP_PAD:
-			/* do nothing */
-			break;
-		case TCMU_OP_CMD:
-			handle_one_command(dev, mb, ent);
-			break;
-		default:
-			/* We don't even know how to handle this TCMU opcode. */
-			ent->hdr.uflags |= TCMU_UFLAG_UNKNOWN_OP;
-		}
-
-		mb->cmd_tail = (mb->cmd_tail + tcmu_hdr_get_len(ent->hdr.len_op)) % mb->cmdr_size;
-		ent = (void *) mb + mb->cmdr_off + mb->cmd_tail;
-		did_some_work = 1;
-	}
-
-	if (did_some_work)
-		poke_kernel(dev->fd);
-
-	return 0;
-}
-
 static void thread_cleanup(void *arg)
 {
 	struct tcmu_device *dev = arg;
@@ -348,7 +288,7 @@ static void *thread_start(void *arg)
 
 	pthread_cleanup_push(thread_cleanup, dev);
 
-	handle_device_events(dev);
+	tcmu_handle_device_events(dev);
 
 	while (1) {
 		char buf[4];
@@ -359,7 +299,7 @@ static void *thread_start(void *arg)
 			break;
 		}
 
-		handle_device_events(dev);
+		tcmu_handle_device_events(dev);
 	}
 
 	errp("thread terminating, should never happen\n");

--- a/main.c
+++ b/main.c
@@ -52,8 +52,6 @@
 
 #define ARRAY_SIZE(X) (sizeof(X) / sizeof((X)[0]))
 
-#define KERN_IFACE_VER 2
-
 static char *handler_path = DEFAULT_HANDLER_PATH;
 static bool debug = false;
 

--- a/tcmu-runner.h
+++ b/tcmu-runner.h
@@ -31,6 +31,8 @@ extern "C" {
 #include <sys/uio.h>
 #include "scsi_defs.h"
 
+#define KERN_IFACE_VER 2
+
 struct tcmu_device {
 	int fd;
 	void *map;

--- a/tcmu-runner.h
+++ b/tcmu-runner.h
@@ -78,10 +78,20 @@ struct tcmu_handler {
 			  struct iovec *iovec, size_t iov_cnt, uint8_t *sense);
 };
 
+/* 
+ * The handler->core API 
+ */
+
+/* each in-process plugin must implement the following */
 void handler_init(void);
 
-/* handler->core API */
+/* plugin-facing API, when running inside the tcmu-runner process */
 void tcmu_register_handler(struct tcmu_handler *handler);
+
+/* the main request-processing loop */
+int tcmu_handle_device_events(struct tcmu_device *dev);
+
+/* aux stuff needed to implement a handler */
 int tcmu_get_attribute(struct tcmu_device *dev, const char *name);
 long long tcmu_get_device_size(struct tcmu_device *dev);
 uint64_t tcmu_get_lba(uint8_t *cdb);
@@ -91,9 +101,6 @@ void tcmu_seek_in_iovec(struct iovec *iovec, size_t count);
 size_t tcmu_memcpy_into_iovec(struct iovec *iovec, size_t iov_cnt, void *src, size_t len);
 size_t tcmu_memcpy_from_iovec(void *dest, size_t len, struct iovec *iovec, size_t iov_cnt);
 size_t tcmu_iovec_length(struct iovec *iovec, size_t iov_cnt);
-
-void dbgp(const char *fmt, ...);
-void errp(const char *fmt, ...);
 
 /*
  * Basic implementations of mandatory SCSI commands that handlers can call if
@@ -106,6 +113,12 @@ int tcmu_emulate_read_capacity_16(uint64_t num_lbas, uint32_t block_size, uint8_
 				  struct iovec *iovec, size_t iov_cnt, uint8_t *sense);
 int tcmu_emulate_mode_sense(uint8_t *cdb, struct iovec *iovec, size_t iov_cnt, uint8_t *sense);
 int tcmu_emulate_mode_select(uint8_t *cdb, struct iovec *iovec, size_t iov_cnt, uint8_t *sense);
+
+/*
+ * These must be implemented by the host process
+ */
+void dbgp(const char *fmt, ...);
+void errp(const char *fmt, ...);
 
 #ifdef __cplusplus
 }

--- a/tcmu-runner.h
+++ b/tcmu-runner.h
@@ -35,7 +35,7 @@ extern "C" {
 
 struct tcmu_device {
 	int fd;
-	void *map;
+	struct tcmu_mailbox *map;
 	size_t map_len;
 	char dev_name[16]; /* e.g. "uio14" */
 	char tcm_hba_name[16]; /* e.g. "user_8" */


### PR DESCRIPTION
Today, tcmu-runner owns the worker threads, thus forcing the users' code into the
plugin structure. This certainly works for minimal examples, but prevents any kind
of embedding into larger 3rd-party applications.

Production-grade applications generally have their own threading structure and want
to deal with socket/file/tcmu notifications in an async way. As such, I just need a
minimal library that handles device opening and command parsing.

There are several API sets now:
 - the API each plugin must implement (unchanged, see tcmu_handler)
 - the API available to the plugin (api.c)
 - the API the host process must implement (debug functions today)
 - the minimal API tcmu_lib will provide (a new concept, builds on api.c)