### PR TITLE
Shared library support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,8 @@ tcmu-runner
 consumer
 *.o
 *.a
-*.so
+handler_*.so
+libtcmu.so*
 *generated.[ch]
 Makefile
 version.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,31 +30,51 @@ find_library(DL dl)
 find_library(KMOD kmod)
 find_library(GFAPI gfapi)
 
-# Stuff for building the main binary
+# Stuff for building the shared library
 add_library(tcmu
+  SHARED
   api.c
   libtcmu.c
   )
+set_target_properties(tcmu
+  PROPERTIES
+  SOVERSION "1"
+  )
+target_include_directories(tcmu
+  PUBLIC ${LIBNL_INCLUDE_DIR}
+  )
+target_link_libraries(tcmu
+  ${LIBNL_LIB}
+  ${LIBNL_GENL_LIB}
+  )
+
+
+# Stuff for building the static library
+add_library(tcmu_static
+  api.c
+  libtcmu.c
+  )
+target_include_directories(tcmu_static
+  PUBLIC ${LIBNL_INCLUDE_DIR}
+  )
+
+# Stuff for building the main binary
 add_executable(tcmu-runner
   main.c
   tcmuhandler-generated.c
   )
 target_link_libraries(tcmu-runner tcmu)
-target_compile_options(tcmu-runner
-  PUBLIC -fPIC -Wl,-E
-  )
 target_include_directories(tcmu-runner
   PUBLIC ${PROJECT_BINARY_DIR}
   PUBLIC ${GLIB_INCLUDE_DIRS}
-  PUBLIC ${LIBNL_INCLUDE_DIR}
   )
 target_link_libraries(tcmu-runner
-  ${LIBNL_LIB}
-  ${LIBNL_GENL_LIB}
   ${GLIB_LIBRARIES}
   ${PTHREAD}
   ${DL}
   ${KMOD}
+  -Wl,--no-export-dynamic
+  -Wl,--dynamic-list=main-syms.txt
   )
 
 add_custom_command(

--- a/consumer.c
+++ b/consumer.c
@@ -12,6 +12,12 @@
  * License for the specific language governing permissions and limitations
  * under the License.
 */
+
+/*
+ * An example of using libtcmu to back one or more types of LIO
+ * userspace passthrough devices.
+ */
+
 #define _DEFAULT_SOURCE
 #include <stdlib.h>
 #include <stdarg.h>
@@ -25,12 +31,13 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <sys/mman.h>
+#include <poll.h>
 
 #include <stdint.h>
 #include <scsi/scsi.h>
 #define _BITS_UIO_H
 #include <linux/target_core_user.h>
-#include "tcmu-runner.h"
+#include "libtcmu.h"
 
 /*
  * Debug API implementation
@@ -52,7 +59,10 @@ void errp(const char *fmt, ...)
 	va_end(va);
 }
 
-struct file_state {
+struct tcmu_device *tcmu_dev_array[128];
+size_t dev_array_len = 0;
+
+struct foo_state {
 	int fd;
 	uint64_t num_lbas;
 	uint32_t block_size;
@@ -63,28 +73,37 @@ static int set_medium_error(uint8_t *sense)
 	return tcmu_set_sense_data(sense, MEDIUM_ERROR, ASC_READ_ERROR, NULL);
 }
 
-static bool file_check_config(const char *cfgstring, char **reason)
+static bool foo_check_config(const char *cfgstring, char **reason)
 {
 	 return true;
 }
 
-static int file_open(struct tcmu_device *dev)
+static int foo_open(struct tcmu_device *dev)
 {
+	/* open the backing file */
+	/* alloc private struct 'foo_state' */
+	/* Save a ptr to it in dev->hm_private */
+
+	/* Add new device to our horrible fixed-length array */
+	tcmu_dev_array[dev_array_len] = dev;
+	dev_array_len++;
+
 	return 0;
 }
 
-static void file_close(struct tcmu_device *dev)
+static void foo_close(struct tcmu_device *dev)
 {
+	/* not supported in this example */
 }
 
-static int file_handle_cmd(
+static int foo_handle_cmd(
 	struct tcmu_device *dev,
 	uint8_t *cdb,
 	struct iovec *iovec,
 	size_t iov_cnt,
 	uint8_t *sense)
 {
-	struct file_state *state = dev->hm_private;
+	struct foo_state *state = tcmu_get_dev_private(dev);
 	uint8_t cmd;
 
 	cmd = cdb[0];
@@ -132,180 +151,80 @@ static int file_handle_cmd(
 	}
 }
 
-static struct tcmu_handler file_handler = {
-	.name = "File-backed Handler (example code)",
-	.subtype = "file",
+static struct tcmulib_handler foo_handler = {
+	.name = "Handler for foo devices (example code)",
+	.subtype = "foo",
 	.cfg_desc = "a description goes here",
 
-	.check_config = file_check_config,
+	.check_config = foo_check_config,
 
-	.open = file_open,
-	.close = file_close,
-	.handle_cmd = file_handle_cmd,
+	.added = foo_open,
+	.removed = foo_close,
 };
-
-static struct tcmu_device *add_device(const char *dev_name, const char *cfgstring)
-{
-	struct tcmu_device *dev;
-	struct tcmu_mailbox *mb;
-	char str_buf[256];
-	int fd;
-	int ret;
-	const char *ptr, *oldptr;
-	int len;
-
-	dev = calloc(1, sizeof(*dev));
-	if (!dev) {
-		errp("calloc failed in add_device\n");
-		return NULL;
-	}
-
-	snprintf(dev->dev_name, sizeof(dev->dev_name), "%s", dev_name);
-
-	oldptr = cfgstring;
-	ptr = strchr(oldptr, '/');
-	if (!ptr) {
-		errp("invalid cfgstring\n");
-		goto err_free;
-	}
-
-	if (strncmp(cfgstring, "tcm-user", ptr-oldptr)) {
-		errp("invalid cfgstring\n");
-		goto err_free;
-	}
-
-	/* Get HBA name */
-	oldptr = ptr+1;
-	ptr = strchr(oldptr, '/');
-	if (!ptr) {
-		errp("invalid cfgstring\n");
-		goto err_free;
-	}
-	len = ptr-oldptr;
-	snprintf(dev->tcm_hba_name, sizeof(dev->tcm_hba_name), "user_%.*s", len, oldptr);
-
-	/* Get device name */
-	oldptr = ptr+1;
-	ptr = strchr(oldptr, '/');
-	if (!ptr) {
-		errp("invalid cfgstring\n");
-		goto err_free;
-	}
-	len = ptr-oldptr;
-	snprintf(dev->tcm_dev_name, sizeof(dev->tcm_dev_name), "%.*s", len, oldptr);
-
-	/* The rest is the handler-specific cfgstring */
-	oldptr = ptr+1;
-	ptr = strchr(oldptr, '/');
-	snprintf(dev->cfgstring, sizeof(dev->cfgstring), "%s", oldptr);
-
-	snprintf(str_buf, sizeof(str_buf), "/dev/%s", dev_name);
-
-	dev->fd = open(str_buf, O_RDWR);
-	if (dev->fd == -1) {
-		errp("could not open %s\n", str_buf);
-		goto err_free;
-	}
-
-	snprintf(str_buf, sizeof(str_buf), "/sys/class/uio/%s/maps/map0/size", dev->dev_name);
-	fd = open(str_buf, O_RDONLY);
-	if (fd == -1) {
-		errp("could not open %s\n", str_buf);
-		goto err_fd_close;
-	}
-
-	ret = read(fd, str_buf, sizeof(str_buf));
-	close(fd);
-	if (ret <= 0) {
-		errp("could not read size of map0\n");
-		goto err_fd_close;
-	}
-	str_buf[ret-1] = '\0'; /* null-terminate and chop off the \n */
-
-	dev->map_len = strtoull(str_buf, NULL, 0);
-	if (dev->map_len == ULLONG_MAX) {
-		errp("could not get map length\n");
-		goto err_fd_close;
-	}
-
-	dev->map = mmap(NULL, dev->map_len, PROT_READ|PROT_WRITE, MAP_SHARED, dev->fd, 0);
-	if (dev->map == MAP_FAILED) {
-		errp("could not mmap: %m\n");
-		goto err_fd_close;
-	}
-
-	mb = dev->map;
-	if (mb->version != KERN_IFACE_VER) {
-		errp("Kernel interface version mismatch: wanted %d got %d\n",
-		    KERN_IFACE_VER, mb->version);
-		goto err_munmap;
-	}
-
-	dev->handler = &file_handler;
-
-	ret = dev->handler->open(dev);
-	if (ret < 0) {
-		errp("handler open failed for %s\n", dev->dev_name);
-		goto err_munmap;
-	}
-
-	return dev;
-
-err_munmap:
-	munmap(dev->map, dev->map_len);
-err_fd_close:
-	close(dev->fd);
-err_free:
-	free(dev);
-
-	return NULL;
-}
 
 int main(int argc, char **argv)
 {
-	struct tcmu_device *dev;
+	struct tcmulib_context *tcmulib_cxt;
+	struct pollfd pollfds[16];
+	int i;
+	int ret;
 
-	/*
-	 * Configure a device
- 	 */
-	{
-		char buf[256];
-		int fd;
-		int ret;
-		const char *path = "/sys/class/uio/uio0/name";
-
-		fd = open(path, O_RDONLY);
-		if (fd == -1) {
-			errp("main: failed to open %s\n", path);
-			return -1;
-		}
-
-		ret = read(fd, buf, sizeof(buf));
-		close(fd);
-		if (ret <= 0 || ret >= sizeof(buf)) {
-			errp("main: failed to read %s\n", path);
-			return -1;
-		}
-		buf[ret-1] = '\0'; /* null-terminate and chop off the \n */
-
-		dev = add_device("uio0", buf);
+	/* If any TCMU devices that exist that match subtype,
+	   handler->added() will now be called from within
+	   tcmulib_initialize(). */
+	tcmulib_cxt = tcmulib_initialize(&foo_handler, 1, NULL);
+	if (tcmulib_cxt < 0) {
+		errp("tcmulib_initialize failed\n");
+		exit(1);
 	}
 
-	if (dev == NULL)
-		return -1;
+	while (1) {
+		pollfds[0].fd = tcmulib_get_master_fd(tcmulib_cxt);
+		pollfds[0].events = POLLIN;
+		pollfds[0].revents = 0;
 
-	/*
-	 * Imagine that we have have just been notified that dev->fd is
-	 * readable via epoll()
- 	 */
-	{
-		char buf[4];
-		int ret = read(dev->fd, buf, 4);
-		if (ret != 4) {
-			errp("Nothing to do. Terminating...\n");
-			return -1;
+		for (i = 0; i < dev_array_len; i++) {
+			pollfds[i+1].fd = tcmu_get_dev_fd(tcmu_dev_array[i]);
+			pollfds[i+1].events = POLLIN;
+			pollfds[i+1].revents = 0;
+		}
+
+		ret = poll(pollfds, dev_array_len+1, -1);
+
+		if (ret <= 0) {
+			errp("poll() returned %d, exiting\n", ret);
+			exit(1);
+		}
+
+		if (pollfds[0].revents) {
+			/* If any tcmu devices have been added or removed, the
+			   added() and removed() handler callbacks will be called
+			   from within this. */
+			tcmulib_master_fd_ready(tcmulib_cxt);
+
+			/* Since devices (may) have changed, re-poll() instead of
+			   processing per-device fds. */
+			continue;
+		}
+
+		for (i = 0; i < dev_array_len; i++) {
+			if (pollfds[i+1].revents) {
+				struct tcmulib_cmd cmd;
+				struct tcmu_device *dev = tcmu_dev_array[i];
+
+				while (tcmulib_get_next_command(dev, &cmd)) {
+					ret = foo_handle_cmd(dev,
+							     cmd.cdb,
+							     cmd.iovec,
+							     cmd.iov_cnt,
+							     cmd.sense_buf);
+					tcmulib_command_complete(dev, &cmd, ret);
+				}
+
+				tcmulib_processing_complete(dev);
+			}
 		}
 	}
 
-	return tcmu_handle_device_events(dev);
+	return 0;
 }

--- a/glfs.c
+++ b/glfs.c
@@ -74,7 +74,7 @@ static int parse_imagepath(
 	char *p, *sep;
 
 	if (!origp)
-		goto fail;;
+		goto fail;
 
 	p = origp;
 	sep = strchr(p, '@');
@@ -167,9 +167,9 @@ static int tcmu_glfs_open(struct tcmu_device *dev)
 
 	gfsp = calloc(1, sizeof(*gfsp));
 	if (!gfsp)
-		return -1;
+		return -ENOMEM;
 
-	dev->hm_private = gfsp;
+	tcmu_set_dev_private(dev, gfsp);
 
 	FETCH_ATTRIBUTE(dev, gfsp->block_size, "hw_block_size");
 
@@ -181,7 +181,7 @@ static int tcmu_glfs_open(struct tcmu_device *dev)
 
 	gfsp->num_lbas = size / gfsp->block_size;
 
-	config = strchr(dev->cfgstring, '/');
+	config = strchr(tcmu_get_dev_cfgstring(dev), '/');
 	if (!config) {
 		errp("no configuration found in cfgstring\n");
 		goto fail;
@@ -245,7 +245,7 @@ fail:
 
 static void tcmu_glfs_close(struct tcmu_device *dev)
 {
-	struct glfs_state *gfsp = dev->hm_private;
+	struct glfs_state *gfsp = tcmu_get_dev_private(dev);
 
 	glfs_close(gfsp->gfd);
 	glfs_fini(gfsp->fs);
@@ -270,7 +270,7 @@ int tcmu_glfs_handle_cmd(
 	size_t iov_cnt,
 	uint8_t *sense)
 {
-	struct glfs_state *state = dev->hm_private;
+	struct glfs_state *state = tcmu_get_dev_private(dev);
 	uint8_t cmd;
 
 	glfs_fd_t *gfd = state->gfd;
@@ -492,7 +492,7 @@ static const char glfs_cfg_desc[] =
 	"  hostname:  The server's hostname\n"
 	"  filename:  The backing file";
 
-struct tcmu_handler glfs_handler = {
+struct tcmur_handler glfs_handler = {
 	.name = "Gluster glfs handler",
 	.subtype = "glfs",
 	.cfg_desc = glfs_cfg_desc,
@@ -507,5 +507,5 @@ struct tcmu_handler glfs_handler = {
 /* Entry point must be named "handler_init". */
 void handler_init(void)
 {
-	tcmu_register_handler(&glfs_handler);
+	tcmur_register_handler(&glfs_handler);
 }

--- a/libtcmu.c
+++ b/libtcmu.c
@@ -11,41 +11,538 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+
+#define _GNU_SOURCE
+#define _BITS_UIO_H
 #include <memory.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <fcntl.h>
 #include <unistd.h>
-
+#include <limits.h>
+#include <sys/mman.h>
+#include <string.h>
 #include <stdint.h>
+#include <stdarg.h>
 #include <errno.h>
+#include <dirent.h>
 #include <scsi/scsi.h>
-#define _BITS_UIO_H
+
 #include <linux/target_core_user.h>
 
-#include "tcmu-runner.h"
+#include <libnl3/netlink/genl/genl.h>
+#include <libnl3/netlink/genl/mngt.h>
+#include <libnl3/netlink/genl/ctrl.h>
 
-static void handle_one_command(struct tcmu_device *dev,
-		       	       struct tcmu_mailbox *mb,
-		       	       struct tcmu_cmd_entry *ent)
+#include "libtcmu.h"
+#include "libtcmu_priv.h"
+
+#define ARRAY_SIZE(X) (sizeof(X) / sizeof((X)[0]))
+
+static struct nla_policy tcmu_attr_policy[TCMU_ATTR_MAX+1] = {
+	[TCMU_ATTR_DEVICE]	= { .type = NLA_STRING },
+	[TCMU_ATTR_MINOR]	= { .type = NLA_U32 },
+};
+
+void errp(struct tcmulib_context_priv *pcxt,
+	  char *fmt, ...)
 {
-	uint8_t *cdb = (void *)mb + ent->req.cdb_off;
-	int i;
-	bool short_cdb = cdb[0] <= 0x1f;
-	int result;
-	uint8_t tmp_sense_buf[TCMU_SENSE_BUFFERSIZE];
-
-	/* Convert iovec addrs in-place to not be offsets */
-	for (i = 0; i < ent->req.iov_cnt; i++)
-		ent->req.iov[i].iov_base = (void *) mb +
-			(size_t)ent->req.iov[i].iov_base;
-
-	for (i = 0; i < (short_cdb ? 6 : 10); i++) {
-		dbgp("%x ", cdb[i]);
+	if (pcxt->err_print) {
+		va_list va;
+		va_start(va, fmt);
+		pcxt->err_print(fmt, va);
+		va_end(va);
 	}
-	dbgp("\n");
+}
 
-	result = dev->handler->handle_cmd(dev, cdb, ent->req.iov,
-					  ent->req.iov_cnt, tmp_sense_buf);
+static int add_device(struct tcmulib_context_priv *pcxt, char *dev_name, char *cfgstring);
+static void remove_device(struct tcmulib_context_priv *pcxt, char *dev_name, char *cfgstring);
+
+static int handle_netlink(struct nl_cache_ops *unused, struct genl_cmd *cmd,
+			  struct genl_info *info, void *arg)
+{
+	struct tcmulib_context_priv *pcxt = arg;
+	char buf[32];
+
+	if (!info->attrs[TCMU_ATTR_MINOR] || !info->attrs[TCMU_ATTR_DEVICE]) {
+		errp(pcxt, "TCMU_ATTR_MINOR or TCMU_ATTR_DEVICE not set, doing nothing\n");
+		return 0;
+	}
+
+	snprintf(buf, sizeof(buf), "uio%d", nla_get_u32(info->attrs[TCMU_ATTR_MINOR]));
+
+	switch (cmd->c_id) {
+	case TCMU_CMD_ADDED_DEVICE:
+		add_device(pcxt, buf, nla_get_string(info->attrs[TCMU_ATTR_DEVICE]));
+		break;
+	case TCMU_CMD_REMOVED_DEVICE:
+		remove_device(pcxt, buf, nla_get_string(info->attrs[TCMU_ATTR_DEVICE]));
+		break;
+	default:
+		errp(pcxt, "Unknown notification %d\n", cmd->c_id);
+	}
+
+	return 0;
+}
+
+static struct genl_cmd tcmu_cmds[] = {
+	{
+		.c_id		= TCMU_CMD_ADDED_DEVICE,
+		.c_name		= "ADDED DEVICE",
+		.c_msg_parser	= handle_netlink,
+		.c_maxattr	= TCMU_ATTR_MAX,
+		.c_attr_policy	= tcmu_attr_policy,
+	},
+	{
+		.c_id		= TCMU_CMD_REMOVED_DEVICE,
+		.c_name		= "REMOVED DEVICE",
+		.c_msg_parser	= handle_netlink,
+		.c_maxattr	= TCMU_ATTR_MAX,
+		.c_attr_policy	= tcmu_attr_policy,
+	},
+};
+
+static struct genl_ops tcmu_ops = {
+	.o_name		= "TCM-USER",
+	.o_cmds		= tcmu_cmds,
+	.o_ncmds	= ARRAY_SIZE(tcmu_cmds),
+};
+
+static struct nl_sock *setup_netlink(struct tcmulib_context_priv *pcxt)
+{
+	struct nl_sock *sock;
+	int ret;
+
+	sock = nl_socket_alloc();
+	if (!sock) {
+		errp(pcxt, "couldn't alloc socket\n");
+		return NULL;
+	}
+
+	nl_socket_disable_seq_check(sock);
+
+	nl_socket_modify_cb(sock, NL_CB_VALID, NL_CB_CUSTOM, genl_handle_msg, pcxt);
+
+	ret = genl_connect(sock);
+	if (ret < 0) {
+		errp(pcxt, "couldn't connect\n");
+		goto err_free;
+	}
+
+	ret = genl_register_family(&tcmu_ops);
+	if (ret < 0) {
+		errp(pcxt, "couldn't register family\n");
+		goto err_close;
+	}
+
+	ret = genl_ops_resolve(sock, &tcmu_ops);
+	if (ret < 0) {
+		errp(pcxt, "couldn't resolve ops, is target_core_user.ko loaded?\n");
+		goto err_close;
+	}
+
+	ret = genl_ctrl_resolve_grp(sock, "TCM-USER", "config");
+
+	ret = nl_socket_add_membership(sock, ret);
+	if (ret < 0) {
+		errp(pcxt, "couldn't add membership\n");
+		goto err_close;
+	}
+
+	return sock;
+
+err_close:
+	nl_close(sock);
+err_free:
+	nl_socket_free(sock);
+
+	return NULL;
+}
+
+static void teardown_netlink(struct nl_sock *sock)
+{
+	nl_close(sock);
+	nl_socket_free(sock);
+}
+
+static struct tcmulib_handler *find_handler(
+	struct tcmulib_context_priv *pcxt,
+	char *cfgstring)
+{
+	struct tcmulib_handler *handler;
+	size_t len;
+	char *found_at;
+
+	found_at = strchrnul(cfgstring, '/');
+	len = found_at - cfgstring;
+
+	darray_foreach(handler, pcxt->handlers) {
+		if (!strncmp(cfgstring, handler->subtype, len))
+		    return handler;
+	}
+
+	return NULL;
+}
+
+static int add_device(struct tcmulib_context_priv *pcxt,
+		      char *dev_name, char *cfgstring)
+{
+	struct tcmu_device *dev;
+	struct tcmu_mailbox *mb;
+	char str_buf[256];
+	int fd;
+	int ret;
+	char *ptr, *oldptr;
+	int len;
+
+	dev = calloc(1, sizeof(*dev));
+	if (!dev) {
+		errp(pcxt, "calloc failed in add_device\n");
+		return -ENOMEM;
+	}
+
+	snprintf(dev->dev_name, sizeof(dev->dev_name), "%s", dev_name);
+
+	oldptr = cfgstring;
+	ptr = strchr(oldptr, '/');
+	if (!ptr) {
+		errp(pcxt, "invalid cfgstring\n");
+		goto err_free;
+	}
+
+	if (strncmp(cfgstring, "tcm-user", ptr-oldptr)) {
+		errp(pcxt, "invalid cfgstring\n");
+		goto err_free;
+	}
+
+	/* Get HBA name */
+	oldptr = ptr+1;
+	ptr = strchr(oldptr, '/');
+	if (!ptr) {
+		errp(pcxt, "invalid cfgstring\n");
+		goto err_free;
+	}
+	len = ptr-oldptr;
+	snprintf(dev->tcm_hba_name, sizeof(dev->tcm_hba_name), "user_%.*s", len, oldptr);
+
+	/* Get device name */
+	oldptr = ptr+1;
+	ptr = strchr(oldptr, '/');
+	if (!ptr) {
+		errp(pcxt, "invalid cfgstring\n");
+		goto err_free;
+	}
+	len = ptr-oldptr;
+	snprintf(dev->tcm_dev_name, sizeof(dev->tcm_dev_name), "%.*s", len, oldptr);
+
+	/* The rest is the handler-specific cfgstring */
+	oldptr = ptr+1;
+	ptr = strchr(oldptr, '/');
+	snprintf(dev->cfgstring, sizeof(dev->cfgstring), "%s", oldptr);
+
+	snprintf(str_buf, sizeof(str_buf), "/dev/%s", dev_name);
+
+	dev->fd = open(str_buf, O_RDWR | O_NONBLOCK | O_CLOEXEC);
+	if (dev->fd == -1) {
+		errp(pcxt, "could not open %s\n", str_buf);
+		goto err_free;
+	}
+
+	snprintf(str_buf, sizeof(str_buf), "/sys/class/uio/%s/maps/map0/size", dev->dev_name);
+	fd = open(str_buf, O_RDONLY);
+	if (fd == -1) {
+		errp(pcxt, "could not open %s\n", str_buf);
+		goto err_fd_close;
+	}
+
+	ret = read(fd, str_buf, sizeof(str_buf));
+	close(fd);
+	if (ret <= 0) {
+		errp(pcxt, "could not read size of map0\n");
+		goto err_fd_close;
+	}
+	str_buf[ret-1] = '\0'; /* null-terminate and chop off the \n */
+
+	dev->map_len = strtoull(str_buf, NULL, 0);
+	if (dev->map_len == ULLONG_MAX) {
+		errp(pcxt, "could not get map length\n");
+		goto err_fd_close;
+	}
+
+	dev->map = mmap(NULL, dev->map_len, PROT_READ|PROT_WRITE, MAP_SHARED, dev->fd, 0);
+	if (dev->map == MAP_FAILED) {
+		errp(pcxt, "could not mmap: %m\n");
+		goto err_fd_close;
+	}
+
+	mb = dev->map;
+	if (mb->version != KERN_IFACE_VER) {
+		errp(pcxt, "Kernel interface version mismatch: wanted %d got %d\n",
+		    KERN_IFACE_VER, mb->version);
+		goto err_munmap;
+	}
+
+	dev->handler = find_handler(pcxt, dev->cfgstring);
+	if (!dev->handler) {
+		errp(pcxt, "could not find handler for %s\n", dev->dev_name);
+		goto err_munmap;
+	}
+
+	dev->pcxt = pcxt;
+
+	darray_append(pcxt->devices, dev);
+
+	ret = dev->handler->added(dev);
+	if (ret < 0) {
+		errp(pcxt, "handler open failed for %s\n", dev->dev_name);
+		goto err_munmap;
+	}
+
+	return 0;
+
+err_munmap:
+	munmap(dev->map, dev->map_len);
+err_fd_close:
+	close(dev->fd);
+err_free:
+	free(dev);
+
+	return -ENOENT;
+}
+
+static void remove_device(struct tcmulib_context_priv *pcxt,
+			  char *dev_name, char *cfgstring)
+{
+	struct tcmu_device **dev_ptr;
+	struct tcmu_device *dev;
+	int i = 0;
+	bool found = false;
+
+	darray_foreach(dev_ptr, pcxt->devices) {
+		dev = *dev_ptr;
+		size_t len = strnlen(dev->dev_name, sizeof(dev->dev_name));
+		if (strncmp(dev->dev_name, dev_name, len)) {
+			i++;
+		} else {
+			found = true;
+			break;
+		}
+	}
+
+	if (!found) {
+		errp(pcxt, "could not remove device %s: not found\n", dev_name);
+		return;
+	}
+
+	dev->handler->removed(dev);
+
+	darray_remove(pcxt->devices, i);
+}
+
+static int is_uio(const struct dirent *dirent)
+{
+	int fd;
+	char tmp_path[64];
+	char buf[256];
+	ssize_t ret;
+
+	if (strncmp(dirent->d_name, "uio", 3))
+		return 0;
+
+	snprintf(tmp_path, sizeof(tmp_path), "/sys/class/uio/%s/name", dirent->d_name);
+
+	fd = open(tmp_path, O_RDONLY);
+	if (fd == -1)
+		return 0;
+
+	ret = read(fd, buf, sizeof(buf));
+	if (ret <= 0 || ret >= sizeof(buf))
+		return 0;
+
+	buf[ret-1] = '\0'; /* null-terminate and chop off the \n */
+
+	/* we only want uio devices whose name is a format we expect */
+	if (strncmp(buf, "tcm-user", 8))
+		return 0;
+
+	return 1;
+}
+
+static int open_devices(struct tcmulib_context_priv *pcxt)
+{
+	struct dirent **dirent_list;
+	int num_devs;
+	int num_good_devs = 0;
+	int i;
+
+	num_devs = scandir("/dev", &dirent_list, is_uio, alphasort);
+
+	if (num_devs == -1)
+		return -1;
+
+	for (i = 0; i < num_devs; i++) {
+		char tmp_path[64];
+		char buf[256];
+		int fd;
+		int ret;
+
+		snprintf(tmp_path, sizeof(tmp_path), "/sys/class/uio/%s/name",
+			 dirent_list[i]->d_name);
+
+		fd = open(tmp_path, O_RDONLY);
+		if (fd == -1) {
+			errp(pcxt, "could not open %s!\n", tmp_path);
+			continue;
+		}
+
+		ret = read(fd, buf, sizeof(buf));
+		close(fd);
+		if (ret <= 0 || ret >= sizeof(buf)) {
+			errp(pcxt, "read of %s had issues\n", tmp_path);
+			continue;
+		}
+		buf[ret-1] = '\0'; /* null-terminate and chop off the \n */
+
+		ret = add_device(pcxt, dirent_list[i]->d_name, buf);
+		if (ret < 0)
+			continue;
+
+		num_good_devs++;
+	}
+
+	for (i = 0; i < num_devs; i++)
+		free(dirent_list[i]);
+	free(dirent_list);
+
+	return num_good_devs;
+}
+
+struct tcmulib_context *tcmulib_initialize(
+	struct tcmulib_handler *handlers,
+	size_t handler_count,
+	void (*err_print)(const char *fmt, ...))
+{
+	struct tcmulib_context_priv *pcxt;
+	int ret;
+	int i;
+
+	pcxt = calloc(1, sizeof(*pcxt));
+	if (!pcxt)
+		return NULL;
+
+	pcxt->nl_sock = setup_netlink(pcxt);
+	if (!pcxt->nl_sock) {
+		free(pcxt);
+		return NULL;
+	}
+
+	darray_init(pcxt->handlers);
+	darray_init(pcxt->devices);
+
+	for (i = 0; i < handler_count; i++)
+		darray_append(pcxt->handlers, handlers[i]);
+
+	ret = open_devices(pcxt);
+	if (ret < 0) {
+		teardown_netlink(pcxt->nl_sock);
+		darray_free(pcxt->handlers);
+		darray_free(pcxt->devices);
+		return NULL;
+	}
+
+	return (struct tcmulib_context *) pcxt;
+}
+
+void tcmulib_close(struct tcmulib_context *cxt)
+{
+	struct tcmulib_context_priv *pcxt = (struct tcmulib_context_priv *)cxt;
+
+	teardown_netlink(pcxt->nl_sock);
+	darray_free(pcxt->handlers);
+	darray_free(pcxt->devices);
+	free(pcxt);
+}
+
+int tcmulib_get_master_fd(struct tcmulib_context *cxt)
+{
+	struct tcmulib_context_priv *pcxt = (struct tcmulib_context_priv *)cxt;
+
+	return nl_socket_get_fd(pcxt->nl_sock);
+}
+
+int tcmulib_master_fd_ready(struct tcmulib_context *cxt)
+{
+	struct tcmulib_context_priv *pcxt = (struct tcmulib_context_priv *)cxt;
+
+	return nl_recvmsgs_default(pcxt->nl_sock);
+}
+
+void *tcmu_get_dev_private(struct tcmu_device *dev)
+{
+	return dev->hm_private;
+}
+
+void tcmu_set_dev_private(struct tcmu_device *dev, void *private)
+{
+	dev->hm_private = private;
+}
+
+int tcmu_get_dev_fd(struct tcmu_device *dev)
+{
+	return dev->fd;
+}
+
+char *tcmu_get_dev_cfgstring(struct tcmu_device *dev)
+{
+	return dev->cfgstring;
+}
+
+struct tcmulib_handler *tcmu_get_dev_handler(struct tcmu_device *dev)
+{
+	return dev->handler;
+}
+
+bool tcmulib_get_next_command(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
+{
+	struct tcmu_mailbox *mb = dev->map;
+	struct tcmu_cmd_entry *ent = (void *) mb + mb->cmdr_off + mb->cmd_tail;
+	int i;
+
+	while (ent != (void *)mb + mb->cmdr_off + mb->cmd_head) {
+
+		switch (tcmu_hdr_get_op(ent->hdr.len_op)) {
+		case TCMU_OP_PAD:
+			/* do nothing */
+			break;
+		case TCMU_OP_CMD:
+			/* Convert iovec addrs in-place to not be offsets */
+			for (i = 0; i < ent->req.iov_cnt; i++)
+				ent->req.iov[i].iov_base = (void *) mb +
+					(size_t)ent->req.iov[i].iov_base;
+
+			cmd->cdb = (void *)mb + ent->req.cdb_off;
+			cmd->iovec = ent->req.iov;
+			cmd->iov_cnt = ent->req.iov_cnt;
+			return true;
+		default:
+			/* We don't even know how to handle this TCMU opcode. */
+			ent->hdr.uflags |= TCMU_UFLAG_UNKNOWN_OP;
+		}
+
+		mb->cmd_tail = (mb->cmd_tail + tcmu_hdr_get_len(ent->hdr.len_op)) % mb->cmdr_size;
+		ent = (void *) mb + mb->cmdr_off + mb->cmd_tail;
+	}
+
+	return false;
+}
+
+void tcmulib_command_complete(
+	struct tcmu_device *dev,
+	struct tcmulib_cmd *cmd,
+	int result)
+{
+	struct tcmu_mailbox *mb = dev->map;
+	struct tcmu_cmd_entry *ent = (void *) mb + mb->cmdr_off + mb->cmd_tail;
 
 	if (result == TCMU_NOT_HANDLED) {
 		/* Tell the kernel we didn't handle it */
@@ -60,52 +557,22 @@ static void handle_one_command(struct tcmu_device *dev,
 		buf[13] = 0x0;  /* ASCQ: (none) */
 	} else {
 		if (result != SAM_STAT_GOOD) {
-			memcpy(ent->rsp.sense_buffer, tmp_sense_buf,
+			memcpy(ent->rsp.sense_buffer, cmd->sense_buf,
 			       TCMU_SENSE_BUFFERSIZE);
 		}
 		ent->rsp.scsi_status = result;
 	}
+
+	mb->cmd_tail = (mb->cmd_tail + tcmu_hdr_get_len(ent->hdr.len_op)) % mb->cmdr_size;
 }
 
-static int poke_kernel(struct tcmu_device *dev)
+void tcmulib_processing_complete(struct tcmu_device *dev)
 {
-	const uint32_t buf = 0xabcdef12;
+	uint32_t buf;
 
-	if (write(dev->fd, &buf, 4) != 4) {
-		errp("poke_kernel write error\n");
-		return -EINVAL;
-	}
+	/* Clear the event on the fd */
+	read(dev->fd, &buf, 4);
 
-	return 0;
-}
-
-int tcmu_handle_device_events(struct tcmu_device *dev)
-{
-	struct tcmu_mailbox *mb = dev->map;
-	struct tcmu_cmd_entry *ent = (void *) mb + mb->cmdr_off + mb->cmd_tail;
-	int did_some_work = 0;
-
-	while (ent != (void *)mb + mb->cmdr_off + mb->cmd_head) {
-
-		switch (tcmu_hdr_get_op(ent->hdr.len_op)) {
-		case TCMU_OP_PAD:
-			/* do nothing */
-			break;
-		case TCMU_OP_CMD:
-			handle_one_command(dev, mb, ent);
-			break;
-		default:
-			/* We don't even know how to handle this TCMU opcode. */
-			ent->hdr.uflags |= TCMU_UFLAG_UNKNOWN_OP;
-		}
-
-		mb->cmd_tail = (mb->cmd_tail + tcmu_hdr_get_len(ent->hdr.len_op)) % mb->cmdr_size;
-		ent = (void *) mb + mb->cmdr_off + mb->cmd_tail;
-		did_some_work = 1;
-	}
-
-	if (did_some_work)
-		return poke_kernel(dev);
-
-	return 0;
+	/* Tell the kernel there are completed commands */
+	write(dev->fd, &buf, 4);
 }

--- a/libtcmu.h
+++ b/libtcmu.h
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2014, Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+*/
+
+/*
+ * This header defines the libtcmu API.
+ */
+
+#ifndef __LIBTCMU_H
+#define __LIBTCMU_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <sys/uio.h>
+#include "scsi_defs.h"
+
+#include "libtcmu_common.h"
+
+struct tcmulib_handler {
+	const char *name;	/* Human-friendly name */
+	const char *subtype;	/* Name for cfgstring matching */
+	const char *cfg_desc;	/* Description of this backstore's config string */
+
+	/*
+	 * As much as possible, check that the cfgstring will result
+	 * in a working device when given to us as dev->cfgstring in
+	 * the ->open() call.
+	 *
+	 * This function is optional but gives configuration tools a
+	 * chance to warn users in advance if the device they're
+	 * trying to create is invalid.
+	 *
+	 * Returns true if string is valid. Only if false, set *reason
+	 * to a string that says why. The string will be free()ed.
+	 * Suggest using asprintf().
+	 */
+	bool (*check_config)(const char *cfgstring, char **reason);
+
+	/* Per-device added/removed callbacks */
+	int (*added)(struct tcmu_device *dev);
+	void (*removed)(struct tcmu_device *dev);
+
+	void *hm_private; /* private ptr for handler module */
+};
+
+#define SENSE_BUFFERSIZE 96
+
+struct tcmulib_cmd {
+	uint8_t *cdb;
+	struct iovec *iovec;
+	size_t iov_cnt;
+	uint8_t sense_buf[SENSE_BUFFERSIZE];
+};
+
+/*
+ * APIs for libtcmu only
+ *
+ * Use these functions to handle TCMU devices and events within an
+ * existing program's event loop.
+ */
+
+struct tcmulib_context;
+
+/* Claim subtypes you wish to handle. Returns libtcmu's master fd or -error.*/
+struct tcmulib_context *tcmulib_initialize(
+	struct tcmulib_handler *handlers,
+	size_t handler_count,
+	void (*err_print)(const char *fmt, ...));
+
+/* Gets the master file descriptor used by tcmulib. */
+int tcmulib_get_master_fd(struct tcmulib_context *cxt);
+
+/*
+ * Call this when the master fd becomes ready, from your main thread.
+ * Handlers' callbacks may be called before it returns.
+ */
+int tcmulib_master_fd_ready(struct tcmulib_context *cxt);
+
+/*
+ * When a device fd becomes ready, call this to get SCSI cmd info in
+ * 'cmd' struct.
+ * Repeat until it returns false.
+ */
+bool tcmulib_get_next_command(struct tcmu_device *dev, struct tcmulib_cmd *cmd);
+
+/*
+ * Mark the command as complete.
+ * Must be called before get_next_command() is called again.
+ *
+ * result is scsi status, or TCMU_NOT_HANDLED.
+ */
+#define TCMU_NOT_HANDLED -1
+void tcmulib_command_complete(struct tcmu_device *dev, struct tcmulib_cmd *cmd, int result);
+
+/* Call when done processing commands (get_next_command() returned false.) */
+void tcmulib_processing_complete(struct tcmu_device *dev);
+
+/* Clean up loose ends when exiting */
+void tcmulib_close(struct tcmulib_context *cxt);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/libtcmu_common.h
+++ b/libtcmu_common.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2014, Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+*/
+
+/*
+ * APIs for both libtcmu users and tcmu-runner plugins to use.
+ */
+
+#ifndef __LIBTCMU_COMMON_H
+#define __LIBTCMU_COMMON_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct tcmu_device;
+
+/* Set/Get methods for the opaque tcmu_device */
+void *tcmu_get_dev_private(struct tcmu_device *dev);
+void tcmu_set_dev_private(struct tcmu_device *dev, void *private);
+int tcmu_get_dev_fd(struct tcmu_device *dev);
+char *tcmu_get_dev_cfgstring(struct tcmu_device *dev);
+struct tcmulib_handler *tcmu_get_dev_handler(struct tcmu_device *dev);
+
+/* Helper routines for processing commands */
+int tcmu_get_attribute(struct tcmu_device *dev, const char *name);
+long long tcmu_get_device_size(struct tcmu_device *dev);
+uint64_t tcmu_get_lba(uint8_t *cdb);
+uint32_t tcmu_get_xfer_length(uint8_t *cdb);
+off_t tcmu_compare_with_iovec(void *mem, struct iovec *iovec, size_t size);
+void tcmu_seek_in_iovec(struct iovec *iovec, size_t count);
+size_t tcmu_memcpy_into_iovec(struct iovec *iovec, size_t iov_cnt, void *src, size_t len);
+size_t tcmu_memcpy_from_iovec(void *dest, size_t len, struct iovec *iovec, size_t iov_cnt);
+size_t tcmu_iovec_length(struct iovec *iovec, size_t iov_cnt);
+
+/* Basic implementations of mandatory SCSI commands */
+int tcmu_set_sense_data(uint8_t *sense_buf, uint8_t key, uint16_t asc_ascq, uint32_t *info);
+int tcmu_emulate_inquiry(struct tcmu_device *dev, uint8_t *cdb, struct iovec *iovec, size_t iov_cnt, uint8_t *sense);
+int tcmu_emulate_test_unit_ready(uint8_t *cdb, struct iovec *iovec, size_t iov_cnt, uint8_t *sense);
+int tcmu_emulate_read_capacity_16(uint64_t num_lbas, uint32_t block_size, uint8_t *cdb,
+				  struct iovec *iovec, size_t iov_cnt, uint8_t *sense);
+int tcmu_emulate_mode_sense(uint8_t *cdb, struct iovec *iovec, size_t iov_cnt, uint8_t *sense);
+int tcmu_emulate_mode_select(uint8_t *cdb, struct iovec *iovec, size_t iov_cnt, uint8_t *sense);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/libtcmu_priv.h
+++ b/libtcmu_priv.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2014, Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+*/
+
+/*
+ * This header defines structures private to libtcmu, and should not
+ * be used by anyone else.
+ */
+
+#ifndef __LIBTCMU_PRIV_H
+#define __LIBTCMU_PRIV_H
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <sys/uio.h>
+
+#include "scsi_defs.h"
+#include "darray.h"
+
+#define KERN_IFACE_VER 2
+
+struct tcmulib_context_priv {
+	darray(struct tcmulib_handler) handlers;
+
+	/* Just keep ptrs b/c we hand these to clients */
+	darray(struct tcmu_device*) devices;
+
+	struct nl_sock *nl_sock;
+
+	void (*err_print)(char *fmt, ...);
+};
+
+void errp(struct tcmulib_context_priv *pcxt,
+	  char *fmt, ...);
+
+struct tcmu_device {
+	int fd;
+	struct tcmu_mailbox *map;
+	size_t map_len;
+	char dev_name[16]; /* e.g. "uio14" */
+	char tcm_hba_name[16]; /* e.g. "user_8" */
+	char tcm_dev_name[128]; /* e.g. "backup2" */
+	char cfgstring[256];
+
+	struct tcmulib_handler *handler;
+	struct tcmulib_context_priv *pcxt;
+
+	void *hm_private; /* private ptr for handler module */
+};
+
+#endif

--- a/main-syms.txt
+++ b/main-syms.txt
@@ -1,0 +1,5 @@
+{
+	tcmur_register_handler;
+	errp;
+	dbgp;
+};


### PR DESCRIPTION
The goal for this branch is to flip things around so TCMU can be used as a library by existing applications such as QEMU or others that have their own event loop. This will require that libtcmu give the client the file descriptors to wait on. This allows the client to have control over the whole spectrum of parallelization options, from every device being handled by a single thread, to each device being given its own thread, or something in between.

libtcmu would handle parsing netlink and also registering as a handler with tcmu-runner over DBus, as well as handling the low-level parts of the TCMU udev interface and supplying basic SCSI command emulation routines that clients can use if desired.

EDIT: libtcmu currently does no DBus (it's all in tcmu-runner). In the future it will make some DBus calls but will still otherwise function if DBus is not present (such as in a containerized environment.)