### PR TITLE
Link tcmu library with --whole-archive so that api.c is always linked…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ add_executable(tcmu-runner
   main.c
   tcmuhandler-generated.c
   )
-target_link_libraries(tcmu-runner tcmu)
+target_link_libraries(tcmu-runner -Wl,--whole-archive tcmu -Wl,--no-whole-archive)
 target_compile_options(tcmu-runner
   PUBLIC -fPIC -Wl,-E
   )


### PR DESCRIPTION
This fixes the following tcmu-runner errors:

vagrant@debian-jessie:~/lio/tcmu-runner$ sudo ./tcmu-runner --handler-path .
Could not open handler at ./handler_file.so: ./handler_file.so: undefined symbol: tcmu_emulate_mode_sense
Could not open handler at ./handler_glfs.so: ./handler_glfs.so: undefined symbol: tcmu_emulate_mode_sense
Could not open handler at ./handler_qcow.so: ./handler_qcow.so: undefined symbol: tcmu_emulate_mode_sense

The root cause of these errors is that api.c.o is not linked in into tcmu-runner as it does not reference any symbols from there.