### PR TITLE
Initialize "list" output parameter for kmod_module_new_from_lookup()

### DIFF
--- a/main.c
+++ b/main.c
@@ -682,7 +682,7 @@ static void dbus_name_lost(GDBusConnection *connection,
 }
 
 int load_our_module(void) {
-	struct kmod_list *list, *itr;
+	struct kmod_list *list = NULL, *itr;
 	int err;
 	struct kmod_ctx *ctx;
 


### PR DESCRIPTION
This fixes the following error when starting up tcmu-runner:

root@debian-jessie:/home/vagrant/lio/tcmu-runner$ sudo ./tcmu-runner 
libkmod: ERROR ../libkmod/libkmod-module.c:531 kmod_module_new_from_lookup: An empty list is needed to create lookup
couldn't load module
root@debian-jessie:/home/vagrant/lio/tcmu-runner$

Environment:

vagrant@debian-jessie:~/lio/tcmu-runner$ dpkg -l libkmod-dev
Desired=Unknown/Install/Remove/Purge/Hold
| Status=Not/Inst/Conf-files/Unpacked/halF-conf/Half-inst/trig-aWait/Trig-pend
|/ Err?=(none)/Reinst-required (Status,Err: uppercase=bad)
||/ Name                  Version         Architecture    Description
+++-=====================-===============-===============-================================================
ii  libkmod-dev:amd64     18-3            amd64           libkmod development files
vagrant@debian-jessie:~/lio/tcmu-runner$ lsb_release -a
No LSB modules are available.
Distributor ID:	Debian
Description:	Debian GNU/Linux 8.2 (jessie)
Release:	8.2
Codename:	jessie
vagrant@debian-jessie:~/lio/tcmu-runner$ 
