### PR TITLE
Async io

### DIFF
--- a/libtcmu.c
+++ b/libtcmu.c
@@ -46,25 +46,8 @@ static void handle_one_command(struct tcmu_device *dev,
 
 	result = dev->handler->handle_cmd(dev, cdb, ent->req.iov,
 					  ent->req.iov_cnt, tmp_sense_buf);
-
-	if (result == TCMU_NOT_HANDLED) {
-		/* Tell the kernel we didn't handle it */
-		char *buf = ent->rsp.sense_buffer;
-
-		ent->rsp.scsi_status = SAM_STAT_CHECK_CONDITION;
-
-		buf[0] = 0x70;  /* fixed, current */
-		buf[2] = 0x5;   /* illegal request */
-		buf[7] = 0xa;
-		buf[12] = 0x20; /* ASC: invalid command operation code */
-		buf[13] = 0x0;  /* ASCQ: (none) */
-	} else {
-		if (result != SAM_STAT_GOOD) {
-			memcpy(ent->rsp.sense_buffer, tmp_sense_buf,
-			       TCMU_SENSE_BUFFERSIZE);
-		}
-		ent->rsp.scsi_status = result;
-	}
+	if (result != TCMU_ASYNC_HANDLED)
+		tcmu_complete_command(dev, ent, result, tmp_sense_buf);
 }
 
 static int poke_kernel(struct tcmu_device *dev)
@@ -79,32 +62,70 @@ static int poke_kernel(struct tcmu_device *dev)
 	return 0;
 }
 
+void tcmu_complete_command(struct tcmu_device *dev, struct tcmu_cmd_entry *ent,
+			   int result, uint8_t *sense)
+{
+	struct tcmu_mailbox *mb = dev->map;
+	struct tcmu_cmd_entry *rsp_ent = (void *) mb + mb->cmdr_off + mb->cmd_tail;
+
+	if (rsp_ent != ent) {
+		uint32_t len_op;
+
+		dbgp("replacing response entry\n");
+		len_op = rsp_ent->hdr.len_op;
+		memcpy(&rsp_ent->hdr, &ent->hdr, sizeof(rsp_ent->hdr));
+		rsp_ent->hdr.len_op = len_op;
+	}
+
+	if (result == TCMU_NOT_HANDLED) {
+		/* Tell the kernel we didn't handle it */
+		char *buf = rsp_ent->rsp.sense_buffer;
+
+		rsp_ent->rsp.scsi_status = SAM_STAT_CHECK_CONDITION;
+
+		buf[0] = 0x70;  /* fixed, current */
+		buf[2] = 0x5;   /* illegal request */
+		buf[7] = 0xa;
+		buf[12] = 0x20; /* ASC: invalid command operation code */
+		buf[13] = 0x0;  /* ASCQ: (none) */
+	} else if (result != TCMU_IGNORED) {
+		if (result != SAM_STAT_GOOD) {
+			memcpy(rsp_ent->rsp.sense_buffer, sense,
+			       sizeof(rsp_ent->rsp.sense_buffer));
+		}
+		rsp_ent->rsp.scsi_status = result;
+	}
+
+	mb->cmd_tail = (mb->cmd_tail + tcmu_hdr_get_len(rsp_ent->hdr.len_op)) % mb->cmdr_size;
+	if ((rsp_ent->hdr.uflags & TCMU_UFLAG_ASYNC) != 0)
+		poke_kernel(dev);
+	else
+		dev->did_some_work = 1;
+}
+
 int tcmu_handle_device_events(struct tcmu_device *dev)
 {
 	struct tcmu_mailbox *mb = dev->map;
-	struct tcmu_cmd_entry *ent = (void *) mb + mb->cmdr_off + mb->cmd_tail;
-	int did_some_work = 0;
+	struct tcmu_cmd_entry *ent;
 
-	while (ent != (void *)mb + mb->cmdr_off + mb->cmd_head) {
+	dev->did_some_work = 0;
+	while ((ent = (void *) mb + mb->cmdr_off + mb->cmd_tail) !=
+			(void *)mb + mb->cmdr_off + mb->cmd_head) {
 
 		switch (tcmu_hdr_get_op(ent->hdr.len_op)) {
+		default:
+			/* We don't even know how to handle this TCMU opcode. */
+			ent->hdr.uflags |= TCMU_UFLAG_UNKNOWN_OP;
+			/* FALLTHRU */
 		case TCMU_OP_PAD:
-			/* do nothing */
+			tcmu_complete_command(dev, ent, TCMU_IGNORED, NULL);
 			break;
 		case TCMU_OP_CMD:
 			handle_one_command(dev, mb, ent);
 			break;
-		default:
-			/* We don't even know how to handle this TCMU opcode. */
-			ent->hdr.uflags |= TCMU_UFLAG_UNKNOWN_OP;
 		}
-
-		mb->cmd_tail = (mb->cmd_tail + tcmu_hdr_get_len(ent->hdr.len_op)) % mb->cmdr_size;
-		ent = (void *) mb + mb->cmdr_off + mb->cmd_tail;
-		did_some_work = 1;
 	}
-
-	if (did_some_work)
+	if (dev->did_some_work)
 		return poke_kernel(dev);
 
 	return 0;

--- a/main.c
+++ b/main.c
@@ -682,7 +682,7 @@ static void dbus_name_lost(GDBusConnection *connection,
 }
 
 int load_our_module(void) {
-	struct kmod_list *list, *itr;
+	struct kmod_list *list = NULL, *itr;
 	int err;
 	struct kmod_ctx *ctx;
 

--- a/tcmu-runner.h
+++ b/tcmu-runner.h
@@ -33,6 +33,8 @@ extern "C" {
 
 #define KERN_IFACE_VER 2
 
+#define TCMU_UFLAG_ASYNC	0x80
+
 struct tcmu_device {
 	int fd;
 	struct tcmu_mailbox *map;
@@ -43,6 +45,7 @@ struct tcmu_device {
 	char cfgstring[256];
 
 	struct tcmu_handler *handler;
+	int did_some_work;
 
 	void *hm_private; /* private ptr for handler module */
 };
@@ -72,6 +75,8 @@ struct tcmu_handler {
 	void (*close)(struct tcmu_device *dev);
 
 #define TCMU_NOT_HANDLED -1
+#define TCMU_ASYNC_HANDLED -2
+#define TCMU_IGNORED -3
 	/*
 	 * Returns SCSI status if handled (either good/bad), or TCMU_NOT_HANDLED
 	 * if opcode is not handled.
@@ -92,6 +97,11 @@ void tcmu_register_handler(struct tcmu_handler *handler);
 
 /* the main request-processing loop */
 int tcmu_handle_device_events(struct tcmu_device *dev);
+
+/* signal command completion */
+struct tcmu_cmd_entry;
+void tcmu_complete_command(struct tcmu_device *dev, struct tcmu_cmd_entry *ent,
+			   int result, uint8_t *sense);
 
 /* aux stuff needed to implement a handler */
 int tcmu_get_attribute(struct tcmu_device *dev, const char *name);


### PR DESCRIPTION
Extend (in backward-compatible way) API to support async command completion:
- handle_cmd should return TCMU_ASYNC_HANDLED
- upon command completion (or timeout) the handler should
set TCMU_UFLAG_ASYNC and call tcmu_complete_command()
