### PR TITLE
Async io

### DIFF
--- a/file_example.c
+++ b/file_example.c
@@ -139,11 +139,12 @@ static int set_medium_error(uint8_t *sense)
  */
 static int file_handle_cmd(
 	struct tcmu_device *dev,
-	uint8_t *cdb,
-	struct iovec *iovec,
-	size_t iov_cnt,
-	uint8_t *sense)
+	struct tcmulib_cmd *tcmulib_cmd)
 {
+	uint8_t *cdb = tcmulib_cmd->cdb;
+	struct iovec *iovec = tcmulib_cmd->iovec;
+	size_t iov_cnt = tcmulib_cmd->iov_cnt;
+	uint8_t *sense = tcmulib_cmd->sense_buf;
 	struct file_state *state = tcmu_get_dev_private(dev);
 	uint8_t cmd;
 	int remaining;

--- a/glfs.c
+++ b/glfs.c
@@ -265,11 +265,12 @@ static int set_medium_error(uint8_t *sense)
  */
 int tcmu_glfs_handle_cmd(
 	struct tcmu_device *dev,
-	uint8_t *cdb,
-	struct iovec *iovec,
-	size_t iov_cnt,
-	uint8_t *sense)
+	struct tcmulib_cmd *tcmulib_cmd)
 {
+	uint8_t *cdb = tcmulib_cmd->cdb;
+	struct iovec *iovec = tcmulib_cmd->iovec;
+	size_t iov_cnt = tcmulib_cmd->iov_cnt;
+	uint8_t *sense = tcmulib_cmd->sense_buf;
 	struct glfs_state *state = tcmu_get_dev_private(dev);
 	uint8_t cmd;
 

--- a/libtcmu.c
+++ b/libtcmu.c
@@ -502,13 +502,25 @@ struct tcmulib_handler *tcmu_get_dev_handler(struct tcmu_device *dev)
 	return dev->handler;
 }
 
+static inline struct tcmu_cmd_entry *
+mailbox_cmd_head(struct tcmu_mailbox *mb)
+{
+	return (struct tcmu_cmd_entry *) ((char *) mb + mb->cmdr_off + mb->cmd_head);
+}
+
+static inline struct tcmu_cmd_entry *
+mailbox_cmd_tail(struct tcmu_mailbox *mb)
+{
+	return (struct tcmu_cmd_entry *) ((char *) mb + mb->cmdr_off + mb->cmd_tail);
+}
+
 bool tcmulib_get_next_command(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
 {
 	struct tcmu_mailbox *mb = dev->map;
-	struct tcmu_cmd_entry *ent = (void *) mb + mb->cmdr_off + mb->cmd_tail;
+	struct tcmu_cmd_entry *ent;
 	int i;
 
-	while (ent != (void *)mb + mb->cmdr_off + mb->cmd_head) {
+	while ((ent = mailbox_cmd_tail(mb)) != mailbox_cmd_head(mb)) {
 
 		switch (tcmu_hdr_get_op(ent->hdr.len_op)) {
 		case TCMU_OP_PAD:
@@ -520,6 +532,7 @@ bool tcmulib_get_next_command(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
 				ent->req.iov[i].iov_base = (void *) mb +
 					(size_t)ent->req.iov[i].iov_base;
 
+			cmd->cmd_id = ent->hdr.cmd_id;
 			cmd->cdb = (void *)mb + ent->req.cdb_off;
 			cmd->iovec = ent->req.iov;
 			cmd->iov_cnt = ent->req.iov_cnt;
@@ -530,7 +543,6 @@ bool tcmulib_get_next_command(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
 		}
 
 		mb->cmd_tail = (mb->cmd_tail + tcmu_hdr_get_len(ent->hdr.len_op)) % mb->cmdr_size;
-		ent = (void *) mb + mb->cmdr_off + mb->cmd_tail;
 	}
 
 	return false;
@@ -542,7 +554,10 @@ void tcmulib_command_complete(
 	int result)
 {
 	struct tcmu_mailbox *mb = dev->map;
-	struct tcmu_cmd_entry *ent = (void *) mb + mb->cmdr_off + mb->cmd_tail;
+	struct tcmu_cmd_entry *ent = mailbox_cmd_tail(mb);
+
+	if (cmd->cmd_id != ent->hdr.cmd_id)
+		ent->hdr.cmd_id = cmd->cmd_id;
 
 	if (result == TCMU_NOT_HANDLED) {
 		/* Tell the kernel we didn't handle it */
@@ -564,6 +579,71 @@ void tcmulib_command_complete(
 	}
 
 	mb->cmd_tail = (mb->cmd_tail + tcmu_hdr_get_len(ent->hdr.len_op)) % mb->cmdr_size;
+}
+
+#define VARIABLE_LENGTH_CMD   0x7f
+
+/* defined in T10 SCSI Primary Commands-2 (SPC2) */
+struct scsi_varlen_cdb_hdr {
+	uint8_t opcode;         /* opcode always == VARIABLE_LENGTH_CMD */
+	uint8_t control;
+	uint8_t misc[5];
+	uint8_t additional_cdb_length;  /* total cdb length - 8 */
+	uint16_t service_action;
+	/* service specific data follows */
+};
+
+static inline unsigned
+scsi_varlen_cdb_length(const void *hdr)
+{
+	 return ((struct scsi_varlen_cdb_hdr *)hdr)->additional_cdb_length + 8;
+}
+
+/* Command group 3 is reserved and should never be used.  */
+static const unsigned char scsi_command_size_tbl[8] =
+{
+	 6, 10, 10, 12,
+	 16, 12, 10, 10
+};
+
+#define COMMAND_SIZE(opcode) scsi_command_size_tbl[((opcode) >> 5) & 7]
+
+static inline unsigned
+scsi_command_size(const unsigned char *cdb)
+{
+	 return (cdb[0] == VARIABLE_LENGTH_CMD) ?
+		 scsi_varlen_cdb_length(cdb) : COMMAND_SIZE(cdb[0]);
+}
+
+struct tcmulib_cmd *tcmulib_async_command_init(struct tcmulib_cmd *cmd)
+{
+	struct tcmulib_cmd *ret;
+	unsigned cdb_len = scsi_command_size(cmd->cdb);
+
+	/* alloc memory for cmd itself, iovec and cdb */
+	ret = malloc(sizeof(*ret) + sizeof(*ret->iovec) * cmd->iov_cnt + cdb_len);
+	if (!ret)
+		return NULL;
+	*ret = *cmd;
+
+	/* copy iovec that currently points to the command ring */
+	ret->iovec = (struct iovec *) (ret + 1);
+	memcpy(ret->iovec, cmd->iovec, cmd->iov_cnt);
+
+	/* copy cdb that currently points to the command ring */
+	ret->cdb = (uint8_t *) (ret->iovec + ret->iov_cnt);
+	memcpy(ret->cdb, cmd->cdb, cdb_len);
+
+	return ret;
+}
+
+void tcmulib_async_command_complete(
+	struct tcmu_device *dev,
+	struct tcmulib_cmd *cmd,
+	int result)
+{
+	tcmulib_command_complete(dev, cmd, result);
+	free(cmd);
 }
 
 void tcmulib_processing_complete(struct tcmu_device *dev)

--- a/libtcmu.h
+++ b/libtcmu.h
@@ -59,15 +59,6 @@ struct tcmulib_handler {
 	void *hm_private; /* private ptr for handler module */
 };
 
-#define SENSE_BUFFERSIZE 96
-
-struct tcmulib_cmd {
-	uint8_t *cdb;
-	struct iovec *iovec;
-	size_t iov_cnt;
-	uint8_t sense_buf[SENSE_BUFFERSIZE];
-};
-
 /*
  * APIs for libtcmu only
  *
@@ -103,10 +94,25 @@ bool tcmulib_get_next_command(struct tcmu_device *dev, struct tcmulib_cmd *cmd);
  * Mark the command as complete.
  * Must be called before get_next_command() is called again.
  *
- * result is scsi status, or TCMU_NOT_HANDLED.
+ * result is scsi status, or TCMU_NOT_HANDLED or TCMU_ASYNC_HANDLED.
  */
-#define TCMU_NOT_HANDLED -1
 void tcmulib_command_complete(struct tcmu_device *dev, struct tcmulib_cmd *cmd, int result);
+
+/*
+ * Init async command completion
+ * Must be called before returning TCMU_ASYNC_HANDLED
+ *
+ * result is the copy of original command that can be safely
+ * processed asynchronously. Command completion should be signalled using
+ * tcmulib_async_command_complete().
+ */
+struct tcmulib_cmd *tcmulib_async_command_init(struct tcmulib_cmd *cmd);
+
+/*
+ * Mark the command as complete.
+ * The command is expected to be obtained from tcmulib_async_command_init()
+ */
+void tcmulib_async_command_complete(struct tcmu_device *dev, struct tcmulib_cmd *cmd, int result);
 
 /* Call when done processing commands (get_next_command() returned false.) */
 void tcmulib_processing_complete(struct tcmu_device *dev);

--- a/libtcmu_common.h
+++ b/libtcmu_common.h
@@ -27,6 +27,19 @@ extern "C" {
 
 struct tcmu_device;
 
+#define TCMU_NOT_HANDLED -1
+#define TCMU_ASYNC_HANDLED -2
+
+#define SENSE_BUFFERSIZE 96
+
+struct tcmulib_cmd {
+	uint16_t cmd_id;
+	uint8_t *cdb;
+	struct iovec *iovec;
+	size_t iov_cnt;
+	uint8_t sense_buf[SENSE_BUFFERSIZE];
+};
+
 /* Set/Get methods for the opaque tcmu_device */
 void *tcmu_get_dev_private(struct tcmu_device *dev);
 void tcmu_set_dev_private(struct tcmu_device *dev, void *private);

--- a/main.c
+++ b/main.c
@@ -177,10 +177,9 @@ static void *thread_start(void *arg)
 			}
 			dbgp("\n");
 
-			ret = r_handler->handle_cmd(dev, cmd.cdb, cmd.iovec,
-						  cmd.iov_cnt, cmd.sense_buf);
-
-			tcmulib_command_complete(dev, &cmd, ret);
+			ret = r_handler->handle_cmd(dev, &cmd);
+			if (ret != TCMU_ASYNC_HANDLED)
+				tcmulib_command_complete(dev, &cmd, ret);
 		}
 
 		tcmulib_processing_complete(dev);

--- a/main.c
+++ b/main.c
@@ -682,7 +682,7 @@ static void dbus_name_lost(GDBusConnection *connection,
 }
 
 int load_our_module(void) {
-	struct kmod_list *list, *itr;
+	struct kmod_list *list = NULL, *itr;
 	int err;
 	struct kmod_ctx *ctx;
 

--- a/qcow.c
+++ b/qcow.c
@@ -813,11 +813,12 @@ static int set_medium_error(uint8_t *sense)
  */
 static int qcow_handle_cmd(
 	struct tcmu_device *dev,
-	uint8_t *cdb,
-	struct iovec *iovec,
-	size_t iov_cnt,
-	uint8_t *sense)
+	struct tcmulib_cmd *tcmulib_cmd)
 {
+	uint8_t *cdb = tcmulib_cmd->cdb;
+	struct iovec *iovec = tcmulib_cmd->iovec;
+	size_t iov_cnt = tcmulib_cmd->iov_cnt;
+	uint8_t *sense = tcmulib_cmd->sense_buf;
 	struct bdev *bdev = tcmu_get_dev_private(dev);
 	uint8_t cmd;
 	ssize_t ret;

--- a/tcmu-runner.h
+++ b/tcmu-runner.h
@@ -57,13 +57,13 @@ struct tcmur_handler {
 	int (*open)(struct tcmu_device *dev);
 	void (*close)(struct tcmu_device *dev);
 
-#define TCMU_NOT_HANDLED -1
 	/*
-	 * Returns SCSI status if handled (either good/bad), or TCMU_NOT_HANDLED
-	 * if opcode is not handled.
+	 * Returns
+	 * - SCSI status if handled (either good/bad)
+	 * - TCMU_NOT_HANDLED if opcode is not handled
+	 * - TCMU_ASYNC_HANDLED if optcode is handled asynchronously
 	 */
-	int (*handle_cmd)(struct tcmu_device *dev, uint8_t *cdb,
-			  struct iovec *iovec, size_t iov_cnt, uint8_t *sense);
+	int (*handle_cmd)(struct tcmu_device *dev, struct tcmulib_cmd *cmd);
 };
 
 /*


### PR DESCRIPTION
This is the proposal for API change to support async handlers.
- async handler is supposed to always return TCMU_ASYNC_HANDLED
- async handler is supposed to use tcmulib_async_command_init() to copy the command
- upon command completion async handler is supposed to use tcmulib_async_command_complete()

Some more comments:
- Probably tcmulib_async_command_init/tcmulib_async_command_init() should be moved to libtcmu_common.h as it seems to be the only header containing the API for handlers
- It looks like you tried to avoid using structs in tcmu-runner.h API (e.g. in handle_cmd()) but using structs allows to extend API without breaking both API (on the source level) and ABI so that compiled handlers are backward compatible, i.e. can be used with tcmu-runner of a newer API version (if this was important at all). For example I needed to pass cmd_id down to all the handler invocation so that it can be passed back when the command is completed
- The use of 'struct tcmulib_cmd' can be pushed down to the other libtcmu_common.h functions (like tcmu_emulate_* functions) but I wanted to have the minimal patch for the start. This can be done later.