### PR TITLE
Async io API proposal

### DIFF
--- a/api.c
+++ b/api.c
@@ -159,34 +159,24 @@ long long tcmu_get_device_size(struct tcmu_device *dev)
 	return size;
 }
 
-#define VARIABLE_LENGTH_CMD   0x7f
-
-/* defined in T10 SCSI Primary Commands-2 (SPC2) */
-struct scsi_varlen_cdb_hdr {
-	uint8_t opcode;         /* opcode always == VARIABLE_LENGTH_CMD */
-	uint8_t control;
-	uint8_t misc[5];
-	uint8_t additional_cdb_length;  /* total cdb length - 8 */
-	uint16_t service_action;
-	/* service specific data follows */
-};
-
-/* Command group 3 is reserved and should never be used.  */
-static const unsigned char scsi_command_size_tbl[8] =
-{
-	 6, 10, 10, 12,
-	 16, 12, 10, 10
-};
-
-#define COMMAND_SIZE(opcode) scsi_command_size_tbl[((opcode) >> 5) & 7]
-
 int tcmu_get_cdb_length(uint8_t *cdb)
 {
 	uint8_t opcode = cdb[0];
 
-	return (opcode == VARIABLE_LENGTH_CMD) ?
-		((struct scsi_varlen_cdb_hdr *) cdb)->additional_cdb_length + 8 :
-		COMMAND_SIZE(opcode);
+	// See spc-4 4.2.5.1 operation code
+	//
+	if (opcode <= 0x1f)
+		return 6;
+	else if (opcode <= 0x5f)
+		return 10;
+	else if (opcode == 0x7f)
+		return cdb[7] + 8;
+	else if (opcode >= 0x80 && opcode <= 0x9f)
+		return 16;
+	else if (opcode >= 0xa0 && opcode <= 0xbf)
+		return 12;
+	else
+		return -EINVAL;
 }
 
 uint64_t tcmu_get_lba(uint8_t *cdb)

--- a/consumer.c
+++ b/consumer.c
@@ -209,16 +209,16 @@ int main(int argc, char **argv)
 
 		for (i = 0; i < dev_array_len; i++) {
 			if (pollfds[i+1].revents) {
-				struct tcmulib_cmd cmd;
+				struct tcmulib_cmd *cmd;
 				struct tcmu_device *dev = tcmu_dev_array[i];
 
-				while (tcmulib_get_next_command(dev, &cmd)) {
+				while ((cmd = tcmulib_get_next_command(dev)) != NULL) {
 					ret = foo_handle_cmd(dev,
-							     cmd.cdb,
-							     cmd.iovec,
-							     cmd.iov_cnt,
-							     cmd.sense_buf);
-					tcmulib_command_complete(dev, &cmd, ret);
+							     cmd->cdb,
+							     cmd->iovec,
+							     cmd->iov_cnt,
+							     cmd->sense_buf);
+					tcmulib_command_complete(dev, cmd, ret);
 				}
 
 				tcmulib_processing_complete(dev);

--- a/file_example.c
+++ b/file_example.c
@@ -139,11 +139,12 @@ static int set_medium_error(uint8_t *sense)
  */
 static int file_handle_cmd(
 	struct tcmu_device *dev,
-	uint8_t *cdb,
-	struct iovec *iovec,
-	size_t iov_cnt,
-	uint8_t *sense)
+	struct tcmulib_cmd *tcmulib_cmd)
 {
+	uint8_t *cdb = tcmulib_cmd->cdb;
+	struct iovec *iovec = tcmulib_cmd->iovec;
+	size_t iov_cnt = tcmulib_cmd->iov_cnt;
+	uint8_t *sense = tcmulib_cmd->sense_buf;
 	struct file_state *state = tcmu_get_dev_private(dev);
 	uint8_t cmd;
 	int remaining;

--- a/glfs.c
+++ b/glfs.c
@@ -265,11 +265,12 @@ static int set_medium_error(uint8_t *sense)
  */
 int tcmu_glfs_handle_cmd(
 	struct tcmu_device *dev,
-	uint8_t *cdb,
-	struct iovec *iovec,
-	size_t iov_cnt,
-	uint8_t *sense)
+	struct tcmulib_cmd *tcmulib_cmd)
 {
+	uint8_t *cdb = tcmulib_cmd->cdb;
+	struct iovec *iovec = tcmulib_cmd->iovec;
+	size_t iov_cnt = tcmulib_cmd->iov_cnt;
+	uint8_t *sense = tcmulib_cmd->sense_buf;
 	struct glfs_state *state = tcmu_get_dev_private(dev);
 	uint8_t cmd;
 

--- a/libtcmu.c
+++ b/libtcmu.c
@@ -519,11 +519,10 @@ device_cmd_tail(struct tcmu_device *dev)
 	return (struct tcmu_cmd_entry *) ((char *) mb + mb->cmdr_off + dev->cmd_tail);
 }
 
-bool tcmulib_get_next_command(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
+struct tcmulib_cmd *tcmulib_get_next_command(struct tcmu_device *dev)
 {
 	struct tcmu_mailbox *mb = dev->map;
 	struct tcmu_cmd_entry *ent;
-	int i;
 
 	while ((ent = device_cmd_tail(dev)) != device_cmd_head(dev)) {
 
@@ -531,18 +530,34 @@ bool tcmulib_get_next_command(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
 		case TCMU_OP_PAD:
 			/* do nothing */
 			break;
-		case TCMU_OP_CMD:
-			/* Convert iovec addrs in-place to not be offsets */
-			for (i = 0; i < ent->req.iov_cnt; i++)
-				ent->req.iov[i].iov_base = (void *) mb +
-					(size_t)ent->req.iov[i].iov_base;
+		case TCMU_OP_CMD: {
+			int i;
+			struct tcmulib_cmd *cmd;
+			uint8_t *cdb = (uint8_t *) mb + ent->req.cdb_off;
+			unsigned cdb_len = tcmu_get_cdb_length(cdb);
 
+			/* Alloc memory for cmd itself, iovec and cdb */
+			cmd = malloc(sizeof(*cmd) + sizeof(*cmd->iovec) * ent->req.iov_cnt + cdb_len);
+			if (!cmd)
+				return NULL;
 			cmd->cmd_id = ent->hdr.cmd_id;
-			cmd->cdb = (void *)mb + ent->req.cdb_off;
-			cmd->iovec = ent->req.iov;
+
+			/* Convert iovec addrs in-place to not be offsets */
 			cmd->iov_cnt = ent->req.iov_cnt;
+			cmd->iovec = (struct iovec *) (cmd + 1);
+			for (i = 0; i < ent->req.iov_cnt; i++) {
+				cmd->iovec[i].iov_base = (void *) mb +
+					(size_t) ent->req.iov[i].iov_base;
+				cmd->iovec[i].iov_len = ent->req.iov[i].iov_len;
+			}
+
+			/* Copy cdb that currently points to the command ring */
+			cmd->cdb = (uint8_t *) (cmd->iovec + cmd->iov_cnt);
+			memcpy(cmd->cdb, (void *) mb + ent->req.cdb_off, cdb_len);
+
 			dev->cmd_tail = (dev->cmd_tail + tcmu_hdr_get_len(ent->hdr.len_op)) % mb->cmdr_size;
-			return true;
+			return cmd;
+		}
 		default:
 			/* We don't even know how to handle this TCMU opcode. */
 			ent->hdr.uflags |= TCMU_UFLAG_UNKNOWN_OP;
@@ -551,7 +566,7 @@ bool tcmulib_get_next_command(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
 		dev->cmd_tail = (dev->cmd_tail + tcmu_hdr_get_len(ent->hdr.len_op)) % mb->cmdr_size;
 	}
 
-	return false;
+	return NULL;
 }
 
 void tcmulib_command_complete(
@@ -570,6 +585,7 @@ void tcmulib_command_complete(
 		ent = (void *) mb + mb->cmdr_off + mb->cmd_tail;
 	}
 
+	/* cmd_id could be different in async case */
 	if (cmd->cmd_id != ent->hdr.cmd_id) {
 		ent->hdr.cmd_id = cmd->cmd_id;
 	}
@@ -594,38 +610,6 @@ void tcmulib_command_complete(
 	}
 
 	mb->cmd_tail = (mb->cmd_tail + tcmu_hdr_get_len(ent->hdr.len_op)) % mb->cmdr_size;
-}
-
-struct tcmulib_cmd *tcmulib_async_command_init(struct tcmulib_cmd *cmd)
-{
-	struct tcmulib_cmd *ret;
-	unsigned cdb_len = tcmu_get_cdb_length(cmd->cdb);
-
-	/* alloc memory for cmd itself, iovec and cdb */
-	ret = malloc(sizeof(*ret) + sizeof(*ret->iovec) * cmd->iov_cnt + cdb_len);
-	if (!ret)
-		return NULL;
-	*ret = *cmd;
-
-	/* copy iovec that currently points to the command ring */
-	ret->iovec = (struct iovec *) (ret + 1);
-	if (cmd->iov_cnt > 0)
-		memcpy(ret->iovec, cmd->iovec, cmd->iov_cnt * sizeof(*ret->iovec));
-
-	/* copy cdb that currently points to the command ring */
-	ret->cdb = (uint8_t *) (ret->iovec + ret->iov_cnt);
-	memcpy(ret->cdb, cmd->cdb, cdb_len);
-
-	return ret;
-}
-
-void tcmulib_async_command_complete(
-	struct tcmu_device *dev,
-	struct tcmulib_cmd *cmd,
-	int result)
-{
-	tcmulib_command_complete(dev, cmd, result);
-	tcmulib_processing_complete(dev);
 	free(cmd);
 }
 

--- a/libtcmu.c
+++ b/libtcmu.c
@@ -548,8 +548,7 @@ bool tcmulib_get_next_command(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
 			ent->hdr.uflags |= TCMU_UFLAG_UNKNOWN_OP;
 		}
 
-		mb->cmd_tail = (mb->cmd_tail + tcmu_hdr_get_len(ent->hdr.len_op)) % mb->cmdr_size;
-		dev->cmd_tail = mb->cmd_tail;
+		dev->cmd_tail = (dev->cmd_tail + tcmu_hdr_get_len(ent->hdr.len_op)) % mb->cmdr_size;
 	}
 
 	return false;
@@ -562,6 +561,14 @@ void tcmulib_command_complete(
 {
 	struct tcmu_mailbox *mb = dev->map;
 	struct tcmu_cmd_entry *ent = (void *) mb + mb->cmdr_off + mb->cmd_tail;
+
+	/* current command could be PAD in async case */
+	while (ent != (void *) mb + mb->cmdr_off + mb->cmd_head) {
+		if (tcmu_hdr_get_op(ent->hdr.len_op) == TCMU_OP_CMD)
+			break;
+		mb->cmd_tail = (mb->cmd_tail + tcmu_hdr_get_len(ent->hdr.len_op)) % mb->cmdr_size;
+		ent = (void *) mb + mb->cmdr_off + mb->cmd_tail;
+	}
 
 	if (cmd->cmd_id != ent->hdr.cmd_id) {
 		ent->hdr.cmd_id = cmd->cmd_id;

--- a/libtcmu.c
+++ b/libtcmu.c
@@ -281,6 +281,7 @@ static int add_device(struct tcmulib_context_priv *pcxt,
 		    KERN_IFACE_VER, mb->version);
 		goto err_munmap;
 	}
+	dev->cmd_tail = mb->cmd_tail;
 
 	dev->handler = find_handler(pcxt, dev->cfgstring);
 	if (!dev->handler) {
@@ -503,15 +504,19 @@ struct tcmulib_handler *tcmu_get_dev_handler(struct tcmu_device *dev)
 }
 
 static inline struct tcmu_cmd_entry *
-mailbox_cmd_head(struct tcmu_mailbox *mb)
+device_cmd_head(struct tcmu_device *dev)
 {
+	struct tcmu_mailbox *mb = dev->map;
+
 	return (struct tcmu_cmd_entry *) ((char *) mb + mb->cmdr_off + mb->cmd_head);
 }
 
 static inline struct tcmu_cmd_entry *
-mailbox_cmd_tail(struct tcmu_mailbox *mb)
+device_cmd_tail(struct tcmu_device *dev)
 {
-	return (struct tcmu_cmd_entry *) ((char *) mb + mb->cmdr_off + mb->cmd_tail);
+	struct tcmu_mailbox *mb = dev->map;
+
+	return (struct tcmu_cmd_entry *) ((char *) mb + mb->cmdr_off + dev->cmd_tail);
 }
 
 bool tcmulib_get_next_command(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
@@ -520,7 +525,7 @@ bool tcmulib_get_next_command(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
 	struct tcmu_cmd_entry *ent;
 	int i;
 
-	while ((ent = mailbox_cmd_tail(mb)) != mailbox_cmd_head(mb)) {
+	while ((ent = device_cmd_tail(dev)) != device_cmd_head(dev)) {
 
 		switch (tcmu_hdr_get_op(ent->hdr.len_op)) {
 		case TCMU_OP_PAD:
@@ -536,6 +541,7 @@ bool tcmulib_get_next_command(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
 			cmd->cdb = (void *)mb + ent->req.cdb_off;
 			cmd->iovec = ent->req.iov;
 			cmd->iov_cnt = ent->req.iov_cnt;
+			dev->cmd_tail = (dev->cmd_tail + tcmu_hdr_get_len(ent->hdr.len_op)) % mb->cmdr_size;
 			return true;
 		default:
 			/* We don't even know how to handle this TCMU opcode. */
@@ -543,6 +549,7 @@ bool tcmulib_get_next_command(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
 		}
 
 		mb->cmd_tail = (mb->cmd_tail + tcmu_hdr_get_len(ent->hdr.len_op)) % mb->cmdr_size;
+		dev->cmd_tail = mb->cmd_tail;
 	}
 
 	return false;
@@ -554,10 +561,11 @@ void tcmulib_command_complete(
 	int result)
 {
 	struct tcmu_mailbox *mb = dev->map;
-	struct tcmu_cmd_entry *ent = mailbox_cmd_tail(mb);
+	struct tcmu_cmd_entry *ent = (void *) mb + mb->cmdr_off + mb->cmd_tail;
 
-	if (cmd->cmd_id != ent->hdr.cmd_id)
+	if (cmd->cmd_id != ent->hdr.cmd_id) {
 		ent->hdr.cmd_id = cmd->cmd_id;
+	}
 
 	if (result == TCMU_NOT_HANDLED) {
 		/* Tell the kernel we didn't handle it */
@@ -628,7 +636,8 @@ struct tcmulib_cmd *tcmulib_async_command_init(struct tcmulib_cmd *cmd)
 
 	/* copy iovec that currently points to the command ring */
 	ret->iovec = (struct iovec *) (ret + 1);
-	memcpy(ret->iovec, cmd->iovec, cmd->iov_cnt);
+	if (cmd->iov_cnt > 0)
+		memcpy(ret->iovec, cmd->iovec, cmd->iov_cnt * sizeof(*ret->iovec));
 
 	/* copy cdb that currently points to the command ring */
 	ret->cdb = (uint8_t *) (ret->iovec + ret->iov_cnt);
@@ -643,6 +652,7 @@ void tcmulib_async_command_complete(
 	int result)
 {
 	tcmulib_command_complete(dev, cmd, result);
+	tcmulib_processing_complete(dev);
 	free(cmd);
 }
 

--- a/libtcmu.c
+++ b/libtcmu.c
@@ -502,13 +502,25 @@ struct tcmulib_handler *tcmu_get_dev_handler(struct tcmu_device *dev)
 	return dev->handler;
 }
 
+static inline struct tcmu_cmd_entry *
+mailbox_cmd_head(struct tcmu_mailbox *mb)
+{
+	return (struct tcmu_cmd_entry *) ((char *) mb + mb->cmdr_off + mb->cmd_head);
+}
+
+static inline struct tcmu_cmd_entry *
+mailbox_cmd_tail(struct tcmu_mailbox *mb)
+{
+	return (struct tcmu_cmd_entry *) ((char *) mb + mb->cmdr_off + mb->cmd_tail);
+}
+
 bool tcmulib_get_next_command(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
 {
 	struct tcmu_mailbox *mb = dev->map;
-	struct tcmu_cmd_entry *ent = (void *) mb + mb->cmdr_off + mb->cmd_tail;
+	struct tcmu_cmd_entry *ent;
 	int i;
 
-	while (ent != (void *)mb + mb->cmdr_off + mb->cmd_head) {
+	while ((ent = mailbox_cmd_tail(mb)) != mailbox_cmd_head(mb)) {
 
 		switch (tcmu_hdr_get_op(ent->hdr.len_op)) {
 		case TCMU_OP_PAD:
@@ -520,6 +532,7 @@ bool tcmulib_get_next_command(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
 				ent->req.iov[i].iov_base = (void *) mb +
 					(size_t)ent->req.iov[i].iov_base;
 
+			cmd->cmd_id = ent->hdr.cmd_id;
 			cmd->cdb = (void *)mb + ent->req.cdb_off;
 			cmd->iovec = ent->req.iov;
 			cmd->iov_cnt = ent->req.iov_cnt;
@@ -530,7 +543,6 @@ bool tcmulib_get_next_command(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
 		}
 
 		mb->cmd_tail = (mb->cmd_tail + tcmu_hdr_get_len(ent->hdr.len_op)) % mb->cmdr_size;
-		ent = (void *) mb + mb->cmdr_off + mb->cmd_tail;
 	}
 
 	return false;
@@ -542,7 +554,10 @@ void tcmulib_command_complete(
 	int result)
 {
 	struct tcmu_mailbox *mb = dev->map;
-	struct tcmu_cmd_entry *ent = (void *) mb + mb->cmdr_off + mb->cmd_tail;
+	struct tcmu_cmd_entry *ent = mailbox_cmd_tail(mb);
+
+	if (cmd->cmd_id != ent->hdr.cmd_id)
+		ent->hdr.cmd_id = cmd->cmd_id;
 
 	if (result == TCMU_NOT_HANDLED) {
 		/* Tell the kernel we didn't handle it */
@@ -564,6 +579,71 @@ void tcmulib_command_complete(
 	}
 
 	mb->cmd_tail = (mb->cmd_tail + tcmu_hdr_get_len(ent->hdr.len_op)) % mb->cmdr_size;
+}
+
+#define VARIABLE_LENGTH_CMD   0x7f
+
+/* defined in T10 SCSI Primary Commands-2 (SPC2) */
+struct scsi_varlen_cdb_hdr {
+	uint8_t opcode;         /* opcode always == VARIABLE_LENGTH_CMD */
+	uint8_t control;
+	uint8_t misc[5];
+	uint8_t additional_cdb_length;  /* total cdb length - 8 */
+	uint16_t service_action;
+	/* service specific data follows */
+};
+
+static inline unsigned
+scsi_varlen_cdb_length(const void *hdr)
+{
+	 return ((struct scsi_varlen_cdb_hdr *)hdr)->additional_cdb_length + 8;
+}
+
+/* Command group 3 is reserved and should never be used.  */
+static const unsigned char scsi_command_size_tbl[8] =
+{
+	 6, 10, 10, 12,
+	 16, 12, 10, 10
+};
+
+#define COMMAND_SIZE(opcode) scsi_command_size_tbl[((opcode) >> 5) & 7]
+
+static inline unsigned
+scsi_command_size(const unsigned char *cdb)
+{
+	 return (cdb[0] == VARIABLE_LENGTH_CMD) ?
+		 scsi_varlen_cdb_length(cdb) : COMMAND_SIZE(cdb[0]);
+}
+
+struct tcmulib_cmd *tcmulib_async_command_init(struct tcmulib_cmd *cmd)
+{
+	struct tcmulib_cmd *ret;
+	unsigned cdb_len = scsi_command_size(cmd->cdb);
+
+	/* alloc memory for cmd itself, iovec and cdb */
+	ret = malloc(sizeof(*ret) + sizeof(*ret->iovec) * cmd->iov_cnt + cdb_len);
+	if (!ret)
+		return NULL;
+	*ret = *cmd;
+
+	/* copy iovec that currently points to the command ring */
+	ret->iovec = (struct iovec *) (ret + 1);
+	memcpy(ret->iovec, cmd->iovec, cmd->iov_cnt);
+
+	/* copy cdb that currently points to the command ring */
+	ret->cdb = (uint8_t *) (ret->iovec + ret->iov_cnt);
+	memcpy(ret->cdb, cmd->cdb, cdb_len);
+
+	return ret;
+}
+
+void tcmulib_async_command_complete(
+	struct tcmu_device *dev,
+	struct tcmulib_cmd *cmd,
+	int result)
+{
+	tcmulib_command_complete(dev, cmd, result);
+	free(cmd);
 }
 
 void tcmulib_processing_complete(struct tcmu_device *dev)

--- a/libtcmu.h
+++ b/libtcmu.h
@@ -59,15 +59,6 @@ struct tcmulib_handler {
 	void *hm_private; /* private ptr for handler module */
 };
 
-#define SENSE_BUFFERSIZE 96
-
-struct tcmulib_cmd {
-	uint8_t *cdb;
-	struct iovec *iovec;
-	size_t iov_cnt;
-	uint8_t sense_buf[SENSE_BUFFERSIZE];
-};
-
 /*
  * APIs for libtcmu only
  *
@@ -103,10 +94,25 @@ bool tcmulib_get_next_command(struct tcmu_device *dev, struct tcmulib_cmd *cmd);
  * Mark the command as complete.
  * Must be called before get_next_command() is called again.
  *
- * result is scsi status, or TCMU_NOT_HANDLED.
+ * result is scsi status, or TCMU_NOT_HANDLED or TCMU_ASYNC_HANDLED.
  */
-#define TCMU_NOT_HANDLED -1
 void tcmulib_command_complete(struct tcmu_device *dev, struct tcmulib_cmd *cmd, int result);
+
+/*
+ * Init async command completion
+ * Must be called before returning TCMU_ASYNC_HANDLED
+ *
+ * result is the copy of original command that can be safely
+ * processed asynchronously. Command completion should be signalled using
+ * tcmulib_async_command_complete().
+ */
+struct tcmulib_cmd *tcmulib_async_command_init(struct tcmulib_cmd *cmd);
+
+/*
+ * Mark the command as complete.
+ * The command is expected to be obtained from tcmulib_async_command_init()
+ */
+void tcmulib_async_command_complete(struct tcmu_device *dev, struct tcmulib_cmd *cmd, int result);
 
 /* Call when done processing commands (get_next_command() returned false.) */
 void tcmulib_processing_complete(struct tcmu_device *dev);

--- a/libtcmu.h
+++ b/libtcmu.h
@@ -88,7 +88,7 @@ int tcmulib_master_fd_ready(struct tcmulib_context *cxt);
  * 'cmd' struct.
  * Repeat until it returns false.
  */
-bool tcmulib_get_next_command(struct tcmu_device *dev, struct tcmulib_cmd *cmd);
+struct tcmulib_cmd *tcmulib_get_next_command(struct tcmu_device *dev);
 
 /*
  * Mark the command as complete.
@@ -97,22 +97,6 @@ bool tcmulib_get_next_command(struct tcmu_device *dev, struct tcmulib_cmd *cmd);
  * result is scsi status, or TCMU_NOT_HANDLED or TCMU_ASYNC_HANDLED.
  */
 void tcmulib_command_complete(struct tcmu_device *dev, struct tcmulib_cmd *cmd, int result);
-
-/*
- * Init async command completion
- * Must be called before returning TCMU_ASYNC_HANDLED
- *
- * result is the copy of original command that can be safely
- * processed asynchronously. Command completion should be signalled using
- * tcmulib_async_command_complete().
- */
-struct tcmulib_cmd *tcmulib_async_command_init(struct tcmulib_cmd *cmd);
-
-/*
- * Mark the command as complete.
- * The command is expected to be obtained from tcmulib_async_command_init()
- */
-void tcmulib_async_command_complete(struct tcmu_device *dev, struct tcmulib_cmd *cmd, int result);
 
 /* Call when done processing commands (get_next_command() returned false.) */
 void tcmulib_processing_complete(struct tcmu_device *dev);

--- a/libtcmu_common.h
+++ b/libtcmu_common.h
@@ -27,6 +27,19 @@ extern "C" {
 
 struct tcmu_device;
 
+#define TCMU_NOT_HANDLED -1
+#define TCMU_ASYNC_HANDLED -2
+
+#define SENSE_BUFFERSIZE 96
+
+struct tcmulib_cmd {
+	uint16_t cmd_id;
+	uint8_t *cdb;
+	struct iovec *iovec;
+	size_t iov_cnt;
+	uint8_t sense_buf[SENSE_BUFFERSIZE];
+};
+
 /* Set/Get methods for the opaque tcmu_device */
 void *tcmu_get_dev_private(struct tcmu_device *dev);
 void tcmu_set_dev_private(struct tcmu_device *dev, void *private);

--- a/libtcmu_common.h
+++ b/libtcmu_common.h
@@ -50,6 +50,7 @@ struct tcmulib_handler *tcmu_get_dev_handler(struct tcmu_device *dev);
 /* Helper routines for processing commands */
 int tcmu_get_attribute(struct tcmu_device *dev, const char *name);
 long long tcmu_get_device_size(struct tcmu_device *dev);
+int tcmu_get_cdb_length(uint8_t *cdb);
 uint64_t tcmu_get_lba(uint8_t *cdb);
 uint32_t tcmu_get_xfer_length(uint8_t *cdb);
 off_t tcmu_compare_with_iovec(void *mem, struct iovec *iovec, size_t size);

--- a/libtcmu_priv.h
+++ b/libtcmu_priv.h
@@ -49,6 +49,8 @@ struct tcmu_device {
 	int fd;
 	struct tcmu_mailbox *map;
 	size_t map_len;
+	uint32_t cmd_tail;
+
 	char dev_name[16]; /* e.g. "uio14" */
 	char tcm_hba_name[16]; /* e.g. "user_8" */
 	char tcm_dev_name[128]; /* e.g. "backup2" */

--- a/main.c
+++ b/main.c
@@ -177,10 +177,9 @@ static void *thread_start(void *arg)
 			}
 			dbgp("\n");
 
-			ret = r_handler->handle_cmd(dev, cmd.cdb, cmd.iovec,
-						  cmd.iov_cnt, cmd.sense_buf);
-
-			tcmulib_command_complete(dev, &cmd, ret);
+			ret = r_handler->handle_cmd(dev, &cmd);
+			if (ret != TCMU_ASYNC_HANDLED)
+				tcmulib_command_complete(dev, &cmd, ret);
 		}
 
 		tcmulib_processing_complete(dev);

--- a/qcow.c
+++ b/qcow.c
@@ -813,11 +813,12 @@ static int set_medium_error(uint8_t *sense)
  */
 static int qcow_handle_cmd(
 	struct tcmu_device *dev,
-	uint8_t *cdb,
-	struct iovec *iovec,
-	size_t iov_cnt,
-	uint8_t *sense)
+	struct tcmulib_cmd *tcmulib_cmd)
 {
+	uint8_t *cdb = tcmulib_cmd->cdb;
+	struct iovec *iovec = tcmulib_cmd->iovec;
+	size_t iov_cnt = tcmulib_cmd->iov_cnt;
+	uint8_t *sense = tcmulib_cmd->sense_buf;
 	struct bdev *bdev = tcmu_get_dev_private(dev);
 	uint8_t cmd;
 	ssize_t ret;

--- a/tcmu-runner.h
+++ b/tcmu-runner.h
@@ -57,13 +57,13 @@ struct tcmur_handler {
 	int (*open)(struct tcmu_device *dev);
 	void (*close)(struct tcmu_device *dev);
 
-#define TCMU_NOT_HANDLED -1
 	/*
-	 * Returns SCSI status if handled (either good/bad), or TCMU_NOT_HANDLED
-	 * if opcode is not handled.
+	 * Returns
+	 * - SCSI status if handled (either good/bad)
+	 * - TCMU_NOT_HANDLED if opcode is not handled
+	 * - TCMU_ASYNC_HANDLED if optcode is handled asynchronously
 	 */
-	int (*handle_cmd)(struct tcmu_device *dev, uint8_t *cdb,
-			  struct iovec *iovec, size_t iov_cnt, uint8_t *sense);
+	int (*handle_cmd)(struct tcmu_device *dev, struct tcmulib_cmd *cmd);
 };
 
 /*


### PR DESCRIPTION
This is the proposal for API change to support async handlers.
- async handler is supposed to always return TCMU_ASYNC_HANDLED
- async handler is supposed to use tcmulib_async_command_init() to copy the command
upon command completion
- async handler is supposed to use tcmulib_async_command_complete()

Some more comments:
- Probably tcmulib_async_command_init/tcmulib_async_command_init() should be moved to libtcmu_common.h as it seems to be the only header containing the API for handlers
- It looks like you tried to avoid using structs in tcmu-runner.h API (e.g. in handle_cmd()) but using structs allows to extend API without breaking both API (on the source level) and ABI so that compiled handlers are backward compatible, i.e. can be used with tcmu-runner of a newer API version (if this was important at all). For example I needed to pass cmd_id down to all the handler invocation so that it can be passed back when the command is completed
- The use of 'struct tcmulib_cmd' can be pushed down to the other libtcmu_common.h functions (like tcmu_emulate_* functions) but I wanted to have the minimal patch for the start. This can be done later.