### PR TITLE
Corrected debug-level printing

### DIFF
--- a/consumer.c
+++ b/consumer.c
@@ -172,9 +172,9 @@ int main(int argc, char **argv)
 	/* If any TCMU devices that exist that match subtype,
 	   handler->added() will now be called from within
 	   tcmulib_initialize(). */
-	tcmulib_cxt = tcmulib_initialize(&foo_handler, 1, NULL);
-	if (tcmulib_cxt < 0) {
-		errp("tcmulib_initialize failed\n");
+	tcmulib_cxt = tcmulib_initialize(&foo_handler, 1, errp);
+	if (tcmulib_cxt <= 0) {
+		errp("tcmulib_initialize failed with %p\n", tcmulib_cxt);
 		exit(1);
 	}
 

--- a/libtcmu_priv.h
+++ b/libtcmu_priv.h
@@ -39,7 +39,7 @@ struct tcmulib_context_priv {
 
 	struct nl_sock *nl_sock;
 
-	void (*err_print)(char *fmt, ...);
+	void (*err_print)(const char *fmt, ...);
 };
 
 void errp(struct tcmulib_context_priv *pcxt,


### PR DESCRIPTION
 - there was a clash between errp() functions
   + these overloads are legal in C++
   + yet might be considered ODR in C (assuming the language uses the term)
 - the printing function must be stashed away
   + and passed in