### PR TITLE
Async IO API proposal:

### DIFF
--- a/api.c
+++ b/api.c
@@ -159,7 +159,7 @@ long long tcmu_get_device_size(struct tcmu_device *dev)
 	return size;
 }
 
-static inline int get_cdb_length(uint8_t *cdb)
+int tcmu_get_cdb_length(uint8_t *cdb)
 {
 	uint8_t opcode = cdb[0];
 
@@ -169,6 +169,8 @@ static inline int get_cdb_length(uint8_t *cdb)
 		return 6;
 	else if (opcode <= 0x5f)
 		return 10;
+	else if (opcode == 0x7f)
+		return cdb[7] + 8;
 	else if (opcode >= 0x80 && opcode <= 0x9f)
 		return 16;
 	else if (opcode >= 0xa0 && opcode <= 0xbf)
@@ -181,7 +183,7 @@ uint64_t tcmu_get_lba(uint8_t *cdb)
 {
 	uint8_t val6;
 
-	switch (get_cdb_length(cdb)) {
+	switch (tcmu_get_cdb_length(cdb)) {
 	case 6:
 		val6 = be16toh(*((uint16_t *)&cdb[2]));
 		return val6 ? val6 : 256;
@@ -198,7 +200,7 @@ uint64_t tcmu_get_lba(uint8_t *cdb)
 
 uint32_t tcmu_get_xfer_length(uint8_t *cdb)
 {
-	switch (get_cdb_length(cdb)) {
+	switch (tcmu_get_cdb_length(cdb)) {
 	case 6:
 		return cdb[4];
 	case 10:

--- a/consumer.c
+++ b/consumer.c
@@ -209,16 +209,16 @@ int main(int argc, char **argv)
 
 		for (i = 0; i < dev_array_len; i++) {
 			if (pollfds[i+1].revents) {
-				struct tcmulib_cmd cmd;
+				struct tcmulib_cmd *cmd;
 				struct tcmu_device *dev = tcmu_dev_array[i];
 
-				while (tcmulib_get_next_command(dev, &cmd)) {
+				while ((cmd = tcmulib_get_next_command(dev)) != NULL) {
 					ret = foo_handle_cmd(dev,
-							     cmd.cdb,
-							     cmd.iovec,
-							     cmd.iov_cnt,
-							     cmd.sense_buf);
-					tcmulib_command_complete(dev, &cmd, ret);
+							     cmd->cdb,
+							     cmd->iovec,
+							     cmd->iov_cnt,
+							     cmd->sense_buf);
+					tcmulib_command_complete(dev, cmd, ret);
 				}
 
 				tcmulib_processing_complete(dev);

--- a/file_example.c
+++ b/file_example.c
@@ -139,11 +139,12 @@ static int set_medium_error(uint8_t *sense)
  */
 static int file_handle_cmd(
 	struct tcmu_device *dev,
-	uint8_t *cdb,
-	struct iovec *iovec,
-	size_t iov_cnt,
-	uint8_t *sense)
+	struct tcmulib_cmd *tcmulib_cmd)
 {
+	uint8_t *cdb = tcmulib_cmd->cdb;
+	struct iovec *iovec = tcmulib_cmd->iovec;
+	size_t iov_cnt = tcmulib_cmd->iov_cnt;
+	uint8_t *sense = tcmulib_cmd->sense_buf;
 	struct file_state *state = tcmu_get_dev_private(dev);
 	uint8_t cmd;
 	int remaining;

--- a/glfs.c
+++ b/glfs.c
@@ -265,11 +265,12 @@ static int set_medium_error(uint8_t *sense)
  */
 int tcmu_glfs_handle_cmd(
 	struct tcmu_device *dev,
-	uint8_t *cdb,
-	struct iovec *iovec,
-	size_t iov_cnt,
-	uint8_t *sense)
+	struct tcmulib_cmd *tcmulib_cmd)
 {
+	uint8_t *cdb = tcmulib_cmd->cdb;
+	struct iovec *iovec = tcmulib_cmd->iovec;
+	size_t iov_cnt = tcmulib_cmd->iov_cnt;
+	uint8_t *sense = tcmulib_cmd->sense_buf;
 	struct glfs_state *state = tcmu_get_dev_private(dev);
 	uint8_t cmd;
 

--- a/libtcmu.h
+++ b/libtcmu.h
@@ -59,15 +59,6 @@ struct tcmulib_handler {
 	void *hm_private; /* private ptr for handler module */
 };
 
-#define SENSE_BUFFERSIZE 96
-
-struct tcmulib_cmd {
-	uint8_t *cdb;
-	struct iovec *iovec;
-	size_t iov_cnt;
-	uint8_t sense_buf[SENSE_BUFFERSIZE];
-};
-
 /*
  * APIs for libtcmu only
  *
@@ -97,15 +88,14 @@ int tcmulib_master_fd_ready(struct tcmulib_context *cxt);
  * 'cmd' struct.
  * Repeat until it returns false.
  */
-bool tcmulib_get_next_command(struct tcmu_device *dev, struct tcmulib_cmd *cmd);
+struct tcmulib_cmd *tcmulib_get_next_command(struct tcmu_device *dev);
 
 /*
  * Mark the command as complete.
  * Must be called before get_next_command() is called again.
  *
- * result is scsi status, or TCMU_NOT_HANDLED.
+ * result is scsi status, or TCMU_NOT_HANDLED or TCMU_ASYNC_HANDLED.
  */
-#define TCMU_NOT_HANDLED -1
 void tcmulib_command_complete(struct tcmu_device *dev, struct tcmulib_cmd *cmd, int result);
 
 /* Call when done processing commands (get_next_command() returned false.) */

--- a/libtcmu_common.h
+++ b/libtcmu_common.h
@@ -27,6 +27,19 @@ extern "C" {
 
 struct tcmu_device;
 
+#define TCMU_NOT_HANDLED -1
+#define TCMU_ASYNC_HANDLED -2
+
+#define SENSE_BUFFERSIZE 96
+
+struct tcmulib_cmd {
+	uint16_t cmd_id;
+	uint8_t *cdb;
+	struct iovec *iovec;
+	size_t iov_cnt;
+	uint8_t sense_buf[SENSE_BUFFERSIZE];
+};
+
 /* Set/Get methods for the opaque tcmu_device */
 void *tcmu_get_dev_private(struct tcmu_device *dev);
 void tcmu_set_dev_private(struct tcmu_device *dev, void *private);
@@ -37,6 +50,7 @@ struct tcmulib_handler *tcmu_get_dev_handler(struct tcmu_device *dev);
 /* Helper routines for processing commands */
 int tcmu_get_attribute(struct tcmu_device *dev, const char *name);
 long long tcmu_get_device_size(struct tcmu_device *dev);
+int tcmu_get_cdb_length(uint8_t *cdb);
 uint64_t tcmu_get_lba(uint8_t *cdb);
 uint32_t tcmu_get_xfer_length(uint8_t *cdb);
 off_t tcmu_compare_with_iovec(void *mem, struct iovec *iovec, size_t size);

--- a/libtcmu_priv.h
+++ b/libtcmu_priv.h
@@ -49,6 +49,8 @@ struct tcmu_device {
 	int fd;
 	struct tcmu_mailbox *map;
 	size_t map_len;
+	uint32_t cmd_tail;
+
 	char dev_name[16]; /* e.g. "uio14" */
 	char tcm_hba_name[16]; /* e.g. "user_8" */
 	char tcm_dev_name[128]; /* e.g. "backup2" */

--- a/main.c
+++ b/main.c
@@ -161,29 +161,33 @@ static void *thread_start(void *arg)
 	struct tcmu_device *dev = arg;
 	struct tcmulib_handler *handler = tcmu_get_dev_handler(dev);
 	struct tcmur_handler *r_handler = handler->hm_private;
-	struct tcmulib_cmd cmd;
 	struct pollfd pfd;
 	int ret;
 
 	pthread_cleanup_push(thread_cleanup, dev);
 
 	while (1) {
-		while (tcmulib_get_next_command(dev, &cmd)) {
+		int completed = 0;
+		struct tcmulib_cmd *cmd;
+
+		while ((cmd = tcmulib_get_next_command(dev)) != NULL) {
 			int i;
-			bool short_cdb = cmd.cdb[0] <= 0x1f;
+			bool short_cdb = cmd->cdb[0] <= 0x1f;
 
 			for (i = 0; i < (short_cdb ? 6 : 10); i++) {
-				dbgp("%x ", cmd.cdb[i]);
+				dbgp("%x ", cmd->cdb[i]);
 			}
 			dbgp("\n");
 
-			ret = r_handler->handle_cmd(dev, cmd.cdb, cmd.iovec,
-						  cmd.iov_cnt, cmd.sense_buf);
-
-			tcmulib_command_complete(dev, &cmd, ret);
+			ret = r_handler->handle_cmd(dev, cmd);
+			if (ret != TCMU_ASYNC_HANDLED) {
+				tcmulib_command_complete(dev, cmd, ret);
+				completed = 1;
+			}
 		}
 
-		tcmulib_processing_complete(dev);
+		if (completed)
+			tcmulib_processing_complete(dev);
 
 		pfd.fd = tcmu_get_dev_fd(dev);
 		pfd.events = POLLIN;

--- a/qcow.c
+++ b/qcow.c
@@ -813,11 +813,12 @@ static int set_medium_error(uint8_t *sense)
  */
 static int qcow_handle_cmd(
 	struct tcmu_device *dev,
-	uint8_t *cdb,
-	struct iovec *iovec,
-	size_t iov_cnt,
-	uint8_t *sense)
+	struct tcmulib_cmd *tcmulib_cmd)
 {
+	uint8_t *cdb = tcmulib_cmd->cdb;
+	struct iovec *iovec = tcmulib_cmd->iovec;
+	size_t iov_cnt = tcmulib_cmd->iov_cnt;
+	uint8_t *sense = tcmulib_cmd->sense_buf;
 	struct bdev *bdev = tcmu_get_dev_private(dev);
 	uint8_t cmd;
 	ssize_t ret;

--- a/tcmu-runner.h
+++ b/tcmu-runner.h
@@ -57,13 +57,13 @@ struct tcmur_handler {
 	int (*open)(struct tcmu_device *dev);
 	void (*close)(struct tcmu_device *dev);
 
-#define TCMU_NOT_HANDLED -1
 	/*
-	 * Returns SCSI status if handled (either good/bad), or TCMU_NOT_HANDLED
-	 * if opcode is not handled.
+	 * Returns
+	 * - SCSI status if handled (either good/bad)
+	 * - TCMU_NOT_HANDLED if opcode is not handled
+	 * - TCMU_ASYNC_HANDLED if optcode is handled asynchronously
 	 */
-	int (*handle_cmd)(struct tcmu_device *dev, uint8_t *cdb,
-			  struct iovec *iovec, size_t iov_cnt, uint8_t *sense);
+	int (*handle_cmd)(struct tcmu_device *dev, struct tcmulib_cmd *cmd);
 };
 
 /*


### PR DESCRIPTION
- the handler can now return TCMU_ASYNC_HANDLED
- tcmulib_get_next_command() now always copies iovec and cdb from the command ring
to the tcmulib_cmd. The returned command can be safely used in async handler.
- rename get_cdb_length() to tcmu_get_cdb_length() and add support for variable-length CDB.