### PR TITLE
Fix a race condition result in userspace blocking to get any command

### DIFF
--- a/consumer.c
+++ b/consumer.c
@@ -212,6 +212,7 @@ int main(int argc, char **argv)
 				struct tcmulib_cmd *cmd;
 				struct tcmu_device *dev = tcmu_dev_array[i];
 
+				tcmulib_processing_start(dev);
 				while ((cmd = tcmulib_get_next_command(dev)) != NULL) {
 					ret = foo_handle_cmd(dev,
 							     cmd->cdb,

--- a/libtcmu.c
+++ b/libtcmu.c
@@ -608,12 +608,17 @@ void tcmulib_command_complete(
 	free(cmd);
 }
 
-void tcmulib_processing_complete(struct tcmu_device *dev)
+void tcmulib_processing_start(struct tcmu_device *dev)
 {
 	uint32_t buf;
 
 	/* Clear the event on the fd */
 	read(dev->fd, &buf, 4);
+}
+
+void tcmulib_processing_complete(struct tcmu_device *dev)
+{
+	uint32_t buf;
 
 	/* Tell the kernel there are completed commands */
 	write(dev->fd, &buf, 4);

--- a/libtcmu.h
+++ b/libtcmu.h
@@ -99,6 +99,11 @@ struct tcmulib_cmd *tcmulib_get_next_command(struct tcmu_device *dev);
  */
 void tcmulib_command_complete(struct tcmu_device *dev, struct tcmulib_cmd *cmd, int result);
 
+/* 
+ * Call before processing commands (before calling get_next_command()) 
+ */
+void tcmulib_processing_start(struct tcmu_device *dev);
+
 /* Call when done processing commands (get_next_command() returned false.) */
 void tcmulib_processing_complete(struct tcmu_device *dev);
 

--- a/main.c
+++ b/main.c
@@ -170,6 +170,7 @@ static void *thread_start(void *arg)
 		int completed = 0;
 		struct tcmulib_cmd *cmd;
 
+		tcmulib_processing_start(dev);
 		while ((cmd = tcmulib_get_next_command(dev)) != NULL) {
 			int i;
 			bool short_cdb = cmd->cdb[0] <= 0x1f;


### PR DESCRIPTION
There is a window between finish the loop search for next command
(tcmulib_get_next_command() and mark the command as received (read uio fd in
tcmulib_processing_complete). If there are commands sent from kernel space
during this time window, userspace would already ack it but unable to pick it
up, which result in hang of userspace process, since polling the uio fd would be
blocked until (if lucky) next command arrives.

This patch introduce tcmulib_processing_start(), which would ack the receiving
of command before tcmulib_get_next_command(), so tcmulib_get_next_command()
wouldn't miss any command from kernel space. Though it may process more commands
than acked, it won't be a problem since we would just let loop runs one more
time to ack them.

The patch is from @yasker. See #12.