### PR TITLE
Fix a race condition result in userspace was blocked infinitely

### DIFF
--- a/consumer.c
+++ b/consumer.c
@@ -212,6 +212,8 @@ int main(int argc, char **argv)
 				struct tcmulib_cmd *cmd;
 				struct tcmu_device *dev = tcmu_dev_array[i];
 
+				tcmulib_processing_start(dev);
+
 				while ((cmd = tcmulib_get_next_command(dev)) != NULL) {
 					ret = foo_handle_cmd(dev,
 							     cmd->cdb,

--- a/libtcmu.c
+++ b/libtcmu.c
@@ -608,12 +608,17 @@ void tcmulib_command_complete(
 	free(cmd);
 }
 
-void tcmulib_processing_complete(struct tcmu_device *dev)
+void tcmulib_processing_start(struct tcmu_device *dev)
 {
 	uint32_t buf;
 
 	/* Clear the event on the fd */
 	read(dev->fd, &buf, 4);
+}
+
+void tcmulib_processing_complete(struct tcmu_device *dev)
+{
+	uint32_t buf;
 
 	/* Tell the kernel there are completed commands */
 	write(dev->fd, &buf, 4);

--- a/libtcmu.h
+++ b/libtcmu.h
@@ -99,7 +99,10 @@ struct tcmulib_cmd *tcmulib_get_next_command(struct tcmu_device *dev);
  */
 void tcmulib_command_complete(struct tcmu_device *dev, struct tcmulib_cmd *cmd, int result);
 
-/* Call when done processing commands (get_next_command() returned false.) */
+/* Call when start processing commands (before calling tcmulib_get_next_command()) */
+void tcmulib_processing_start(struct tcmu_device *dev);
+
+/* Call when complete processing commands (tcmulib_get_next_command() returned NULL) */
 void tcmulib_processing_complete(struct tcmu_device *dev);
 
 /* Clean up loose ends when exiting */

--- a/main.c
+++ b/main.c
@@ -170,6 +170,8 @@ static void *thread_start(void *arg)
 		int completed = 0;
 		struct tcmulib_cmd *cmd;
 
+		tcmulib_processing_start(dev);
+
 		while ((cmd = tcmulib_get_next_command(dev)) != NULL) {
 			int i;
 			bool short_cdb = cmd->cdb[0] <= 0x1f;


### PR DESCRIPTION
Fix a race condition result in userspace was blocked infinitely

The currently kernel/userspace command handling logic is:

```
while (1) {

	while (tcmulib_get_next_command()) {
		// handle
	}

	if (complete) {
		read(fd); // ack that userspace received event
		write(fd); // ack that userspace complete the event
	}
}
```

But there is a window between finish the searching for next command
`tcmulib_get_next_command()` and mark the command as received (`read(fd)` in
`tcmulib_processing_complete()`), because we handle the command first then ack it
later. We won't know if there are commands sent from kernel space
after tcmulib_get_next_command() return false but before we read(fd) to ack the
event, then we would ack the receiving of new commands by mistake. Then polling
the uio fd would be blocked until (if lucky enough) next command arrives, or
blocking forever.

To make the process right, we need to always `read(fd)` to ack the event before
starting process the commands.  This patch introduces
`tcmulib_processing_start()`, which would ack the receiving of command before
`tcmulib_get_next_command()`. Though it may process more commands than acked, it
won't be a problem since we would just let loop runs one more time to ack them.

When hanging happened, `iostat -xk 1` would report something like this, notice
`avgqu-sz`(these are commands we lost during the window), and `%util`(which would be
always 100%).

```
Device:         rrqm/s   wrqm/s     r/s     w/s    rkB/s    wkB/s avgrq-sz
avgqu-sz   await r_await w_await  svctm  %util
sda               0.00     0.00    0.00    0.00     0.00     0.00     0.00
160.00    0.00    0.00    0.00   0.00 100.00
```