### PR TITLE
libtcmu.h: Don't include scsi_defs.h

### DIFF
--- a/api.c
+++ b/api.c
@@ -53,20 +53,20 @@ int tcmu_get_attribute(struct tcmu_device *dev, const char *name)
 
 	fd = open(path, O_RDONLY);
 	if (fd == -1) {
-		errp(dev->cxt, "Could not open configfs to read attribute %s\n", name);
+		tcmu_errp(dev->cxt, "Could not open configfs to read attribute %s\n", name);
 		return -EINVAL;
 	}
 
 	ret = read(fd, buf, sizeof(buf));
 	close(fd);
 	if (ret == -1) {
-		errp(dev->cxt, "Could not read configfs to read attribute %s\n", name);
+		tcmu_errp(dev->cxt, "Could not read configfs to read attribute %s\n", name);
 		return -EINVAL;
 	}
 
 	val = strtoul(buf, NULL, 0);
 	if (val == ULONG_MAX) {
-		errp(dev->cxt, "could not convert string to value\n");
+		tcmu_errp(dev->cxt, "could not convert string to value\n");
 		return -EINVAL;
 	}
 
@@ -93,14 +93,14 @@ static char *tcmu_get_wwn(struct tcmu_device *dev)
 
 	fd = open(path, O_RDONLY);
 	if (fd == -1) {
-		errp(dev->cxt, "Could not open configfs to read unit serial\n");
+		tcmu_errp(dev->cxt, "Could not open configfs to read unit serial\n");
 		return NULL;
 	}
 
 	ret = read(fd, buf, sizeof(buf));
 	close(fd);
 	if (ret == -1) {
-		errp(dev->cxt, "Could not read configfs to read unit serial\n");
+		tcmu_errp(dev->cxt, "Could not read configfs to read unit serial\n");
 		return NULL;
 	}
 
@@ -110,7 +110,7 @@ static char *tcmu_get_wwn(struct tcmu_device *dev)
 	/* Skip to the good stuff */
 	ret = asprintf(&ret_buf, "%s", &buf[28]);
 	if (ret == -1) {
-		errp(dev->cxt, "could not convert string to value\n");
+		tcmu_errp(dev->cxt, "could not convert string to value\n");
 		return NULL;
 	}
 
@@ -131,28 +131,28 @@ long long tcmu_get_device_size(struct tcmu_device *dev)
 
 	fd = open(path, O_RDONLY);
 	if (fd == -1) {
-		errp(dev->cxt, "Could not open configfs to read dev info\n");
+		tcmu_errp(dev->cxt, "Could not open configfs to read dev info\n");
 		return -EINVAL;
 	}
 
 	ret = read(fd, buf, sizeof(buf));
 	close(fd);
 	if (ret == -1) {
-		errp(dev->cxt, "Could not read configfs to read dev info\n");
+		tcmu_errp(dev->cxt, "Could not read configfs to read dev info\n");
 		return -EINVAL;
 	}
 	buf[sizeof(buf)-1] = '\0'; /* paranoid? Ensure null terminated */
 
 	rover = strstr(buf, " Size: ");
 	if (!rover) {
-		errp(dev->cxt, "Could not find \" Size: \" in %s\n", path);
+		tcmu_errp(dev->cxt, "Could not find \" Size: \" in %s\n", path);
 		return -EINVAL;
 	}
 	rover += 7; /* get to the value */
 
 	size = strtoull(rover, NULL, 0);
 	if (size == ULLONG_MAX) {
-		errp(dev->cxt, "Could not get size\n");
+		tcmu_errp(dev->cxt, "Could not get size\n");
 		return -EINVAL;
 	}
 

--- a/consumer.c
+++ b/consumer.c
@@ -38,6 +38,7 @@
 #define _BITS_UIO_H
 #include <linux/target_core_user.h>
 #include "libtcmu.h"
+#include "scsi_defs.h"
 
 /*
  * Debug API implementation

--- a/libtcmu.h
+++ b/libtcmu.h
@@ -28,7 +28,6 @@ extern "C" {
 #include <stdbool.h>
 #include <stdint.h>
 #include <sys/uio.h>
-#include "scsi_defs.h"
 
 #include "libtcmu_common.h"
 

--- a/libtcmu_priv.h
+++ b/libtcmu_priv.h
@@ -43,8 +43,7 @@ struct tcmulib_context {
 	void (*err_print)(const char *fmt, ...);
 };
 
-void errp(struct tcmulib_context *cxt,
-	  char *fmt, ...);
+void tcmu_errp(struct tcmulib_context *cxt, char *fmt, ...);
 
 struct tcmu_device {
 	int fd;


### PR DESCRIPTION
A couple fixes to let me correctly link to libtcmu with the following dummy application (configure detection snippet):

#include <stdio.h>
#include <libtcmu.h>

int main(int argc, char **argv)
{
  struct tcmulib_context *ctx = tcmulib_initialize(NULL, 0, NULL);
  return ctx != NULL;
}

