### PR TITLE
cmake: Optional build dependency on glusterfs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,19 +112,23 @@ add_executable(consumer
   )
 target_link_libraries(consumer tcmu)
 
-# Stuff for building the glfs handler
-add_library(handler_glfs
-  SHARED
-  glfs.c
-  )
-set_target_properties(handler_glfs
-  PROPERTIES
-  PREFIX ""
-  )
-target_link_libraries(handler_glfs
-  ${GFAPI}
-  )
-install(TARGETS handler_glfs DESTINATION ${CMAKE_INSTALL_LIBDIR}/tcmu-runner)
+if (GFAPI_INCLUDE_DIR)
+  # Stuff for building the glfs handler
+  add_library(handler_glfs
+    SHARED
+    glfs.c
+    )
+  set_target_properties(handler_glfs
+    PROPERTIES
+    PREFIX ""
+    )
+  target_link_libraries(handler_glfs
+    ${GFAPI}
+    )
+  install(TARGETS handler_glfs DESTINATION ${CMAKE_INSTALL_LIBDIR}/tcmu-runner)
+else()
+  MESSAGE("Disabled GlusterFS support")
+endif()
 
 # Stuff for building the qcow handler
 add_library(handler_qcow

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ We encourage pull requests and issues tracking via Github, and the [target-devel
 
 1. Install cmake.
 1. Clone this repo.
-1. Install development packages for dependencies: libnl3, libglib2 (or glib2-devel on Fedora), libpthread, libdl, libkmod, libgfapi (Gluster), zlib.
+1. Install development packages for dependencies: libnl3, libglib2 (or glib2-devel on Fedora), libpthread, libdl, libkmod, zlib and optionally libgfapi (or glusterfs-api-devel on Fedora).
 1. Type `cmake .`.
 1. Type `make`.
 


### PR DESCRIPTION
Don't build glfs handler if gluster api headers are not found. Print a
warning in cmake.

Signed-off-by: Fam Zheng <famz@redhat.com>