### PR TITLE
glfs: fix some WRITE error paths

### DIFF
--- a/glfs.c
+++ b/glfs.c
@@ -434,8 +434,10 @@ write:
 			if (((cmd != WRITE_6) && (cdb[1] & 0x8))
 			    || !state->wce)
 				glfs_fdatasync(gfd);
-		} else
+		} else {
 			result = set_medium_error(sense);
+			break;
+		}
 
 		if (!do_verify)
 			break;
@@ -451,6 +453,7 @@ write:
 
 		if (ret != length) {
 			result = set_medium_error(sense);
+			free(tmpbuf);
 			break;
 		}
 


### PR DESCRIPTION
I'm using glfs as the basis for a new handler and came across these. They are untested but look pretty straightforward.