### PR TITLE
build: fix tcmu-runner_HANDLER_PATH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -std=c99")
 
 include(GNUInstallDirs)
 
-set(tcmu-runner_HANDLER_PATH "/usr/${CMAKE_INSTALL_LIBDIR}/tcmu-runner")
+set(tcmu-runner_HANDLER_PATH "${CMAKE_INSTALL_LIBDIR}/tcmu-runner")
 
 option(with-glfs "build Gluster glfs handler" true)
 option(with-qcow "build qcow handler" true)


### PR DESCRIPTION
glfs and qcow handlers are installed under
${CMAKE_INSTALL_LIBDIR}/tcmu-runner, but tcmu-runner_HANDLER_PATH
currently carries a "/usr/" prefix. As a result the tcmu-runner binary
can't locate the handlers unless an explicit --handler-path parameter
is specified.

Signed-off-by: David Disseldorp <ddiss@suse.de>