### PR TITLE
Alloc inclusion of falloc.h when needed. (Issue #52)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,6 +144,12 @@ if (with-qcow)
 	  PROPERTIES
 	  PREFIX ""
 	  )
+	if (HAVE_LINUX_FALLOC)
+		set_target_properties(handler_qcow
+		  PROPERTIES
+		  COMPILE_FLAGS "-DHAVE_LINUX_FALLOC"
+		  )
+	endif (HAVE_LINUX_FALLOC)
 	target_link_libraries(handler_qcow
 	  ${ZLIB_LIBRARIES}
 	  )

--- a/qcow.c
+++ b/qcow.c
@@ -64,6 +64,9 @@
 #include <assert.h>
 
 #include <zlib.h>
+#if defined(HAVE_LINUX_FALLOC)
+#include <linux/falloc.h>
+#endif
 
 #include "tcmu-runner.h"
 #include "scsi_defs.h"


### PR DESCRIPTION
The fallocate() call in qcow.c uses FALLOC_FL_ZERO_RANGE,
but this macro is defined in <linux/falloc.h> on some systems,
so make this inclusion possible with an ifdef.

See Issue #52 