### PR TITLE
Fix tcmu_errp() for variadic argument

### DIFF
--- a/libtcmu.c
+++ b/libtcmu.c
@@ -44,16 +44,6 @@ static struct nla_policy tcmu_attr_policy[TCMU_ATTR_MAX+1] = {
 	[TCMU_ATTR_MINOR]	= { .type = NLA_U32 },
 };
 
-void tcmu_errp(struct tcmulib_context *ctx, char *fmt, ...)
-{
-	if (ctx->err_print) {
-		va_list va;
-		va_start(va, fmt);
-		ctx->err_print(fmt, va);
-		va_end(va);
-	}
-}
-
 static int add_device(struct tcmulib_context *ctx, char *dev_name, char *cfgstring);
 static void remove_device(struct tcmulib_context *ctx, char *dev_name, char *cfgstring);
 

--- a/libtcmu_priv.h
+++ b/libtcmu_priv.h
@@ -43,7 +43,7 @@ struct tcmulib_context {
 	void (*err_print)(const char *fmt, ...);
 };
 
-void tcmu_errp(struct tcmulib_context *ctx, char *fmt, ...);
+#define tcmu_errp(ctx, fmt, ...) if ((ctx)->err_print) { (ctx)->err_print((fmt),##__VA_ARGS__);}
 
 struct tcmu_device {
 	int fd;


### PR DESCRIPTION
It's not possible to pass variadic argument to another function, so macro has
to be used.